### PR TITLE
Fix typo in pom.xml, causing build error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
       <description>Hibernate ORM (Hibernate in short) is an object-relational mapping library for the Java language,
  providing a framework for mapping an object-oriented domain model to a traditional relational database. 
  Hibernate solves object-relational impedance mismatch problems by replacing direct persistence-related 
- database accesses with high-level object handling functions.</dexcription>
+ database accesses with high-level object handling functions.</description>
       <class>org.lucee.extension.orm.hibernate.HibernateORMEngine</class>
   </properties>
 


### PR DESCRIPTION
When I try to run `mvn` on this extension, I get the following error:

```
[ERROR]     Non-parseable POM C:\Users\Michael Born\server\opensource\extension-hibernate\pom.xml: end tag name </dexcription> must be the same as start tag <description> from line 17 (position: TEXT seen ... accesses with high-level object handling functions.</dexcription>... @20:76)  @ line 20, column 76 -> [Help 2]
```

It's fairly obvious why - the `</dexcription>` element is a typo. Easy fix.