### PR TITLE
Don't use DatasourceManager in ORM extension when creating mappings

### DIFF
--- a/source/java/src/org/lucee/extension/orm/hibernate/HibernateORMEngine.java
+++ b/source/java/src/org/lucee/extension/orm/hibernate/HibernateORMEngine.java
@@ -272,14 +272,13 @@ public class HibernateORMEngine implements ORMEngine {
 				root = doc.createElement("hibernate-mapping");
 				doc.appendChild(root);
 				pc.addPageSource(cfc.getPageSource(), true);
-				DataSourceManager manager = pc.getDataSourceManager();
-				DatasourceConnection dc = manager.getConnection(pc, ds, null, null);
+				DatasourceConnection dc = CommonUtil.getDatasourceConnection(pc, ds, null, null);
 				try {
 					HBMCreator.createXMLMapping(pc, dc, cfc, root, data);
 				}
 				finally {
 					pc.removeLastPageSource(true);
-					manager.releaseConnection(pc, dc);
+					CommonUtil.releaseDatasourceConnection(pc, dc);
 				}
 				try {
 					xml = XMLUtil.toString(root.getChildNodes(), true, true);


### PR DESCRIPTION
There's no need to use the manager to create and release connections. This just adds the chance that an `ormDatasourceConnection` instance will be passed to a `queryExecute()` call - see LDEV-1564.

Resolves the _potential_ for LDEV-1564.