### PR TITLE
LDEV-3641: Correct positional parameter set in Hibernate v5.3+

### DIFF
--- a/source/java/src/org/lucee/extension/orm/hibernate/HibernateORMSession.java
+++ b/source/java/src/org/lucee/extension/orm/hibernate/HibernateORMSession.java
@@ -553,16 +553,7 @@ public class HibernateORMSession implements ORMSession {
 						// HibernateCaster.toHibernateType(item.getType(), null); MUST
 						// query.setParameter(index, item.getValue(),type);
 					}
-					if (meta != null) {
-						type = meta.getOrdinalParameterExpectedType(index + 1);
-						obj = HibernateCaster.toSQL(type, obj, isArray);
-						// TOOD can the following be done somehow
-						// if(isArray.toBooleanValue())
-						// query.setParameterList(index, (Object[])obj,type);
-						// else
-						query.setParameter(index, obj, type);
-					}
-					else query.setParameter(index, obj);
+					query.setParameter( index+1, obj );
 					index++;
 				}
 				if (meta.getOrdinalParameterCount() > index) throw ExceptionUtil.createException(this, null,


### PR DESCRIPTION
This PR resolves LDEV-3641 on the v5.4 extension.

Feel free to pick this apart - I'm not a Java dev, after all!

The typing is especially weird - it seems overly strict for Hibernate to throw an error when all we're trying to do is ascertain the type before adding the parameter.

Would a better fix be adding the parameter via `query.setParameter( index, obj )` and _then_ running `meta.getOrdinalParameterExpectedType()` to check the type? The type could then be set via `query.setParameter( index, obj, type )`.