### PR TITLE
LDEV-6159 this.logs support, lifecycle logging, test coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 5.6.15.13
+
+### Improvements
+
+- ORM logging now respects application-level `this.logs` overrides (Lucee 7.0+). Each application can independently control the orm log level without affecting other apps on the server
+- Added lifecycle logging at DEBUG level: "ORM initializing", "ORM initialized" (with entity count and settings), and "ormReload()" messages
+
 ## 5.6.15.12
 
 ### Performance

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.lucee</groupId>
     <artifactId>hibernate-extension</artifactId>
-    <version>5.6.15.12-SNAPSHOT</version>
+    <version>5.6.15.13-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Hibernate Extension</name>
 

--- a/source/java/src/org/lucee/extension/orm/hibernate/HibernateORMEngine.java
+++ b/source/java/src/org/lucee/extension/orm/hibernate/HibernateORMEngine.java
@@ -95,6 +95,10 @@ public class HibernateORMEngine implements ORMEngine {
 	public boolean reload(PageContext pc, boolean force) throws PageException {
 		String appName = pc.getApplicationContext().getName();
 		if (force || !isInitializedForApplication(appName)) {
+			if ( force ) {
+				Log log = CommonUtil.getORMLog( pc );
+				if ( log != null ) log.log( Log.LEVEL_DEBUG, "hibernate", "ormReload() for application [" + appName + "]" );
+			}
 			synchronized (INIT_LOCK) {
 				if (force || !isInitializedForApplication(appName)) {
 					buildSessionFactoryData(pc);
@@ -186,10 +190,17 @@ public class HibernateORMEngine implements ORMEngine {
 
 		// Configure ORM logging BEFORE Hibernate classes load, so level filtering is active
 		// from the start.
-		Log log = pc.getConfig().getLog( "orm" );
+		Log log = CommonUtil.getORMLog( pc );
 		OrmLoggingSettings logSettings = OrmLoggingSettings.load( pc, ormConf );
 		LoggerLevelManager.configure( log, logSettings.logSQL, logSettings.logParams,
 		    logSettings.logCache, logSettings.logVerbose );
+
+		if ( log != null ) {
+			log.log( Log.LEVEL_DEBUG, "hibernate",
+				"ORM initializing for application [" + applicationName + "], dbcreate [" + dbCreateLabel( ormConf.getDbCreate() ) + "]" );
+			String dbCreateWarning = OrmLoggingSettings.checkDbCreate( pc, ormConf.getDbCreate() );
+			if ( dbCreateWarning != null ) log.log( Log.LEVEL_WARN, "hibernate", dbCreateWarning );
+		}
 
 		SessionFactoryData data = new SessionFactoryData(this, ormConf);
 		setSessionFactory(applicationName, data);
@@ -266,6 +277,9 @@ public class HibernateORMEngine implements ORMEngine {
 
 			data.buildSessionFactory(e.getKey());
 		}
+
+		if ( log != null ) log.log( Log.LEVEL_DEBUG, "hibernate",
+			"ORM initialized [" + data.sizeCFCs() + "] entities for application [" + applicationName + "], " + logSettings );
 
 		return data;
 	}
@@ -402,6 +416,18 @@ public class HibernateORMEngine implements ORMEngine {
 			return cfc;
 		}
 		return null;
+	}
+
+	private static String dbCreateLabel( int dbCreate ) {
+		switch ( dbCreate ) {
+			case ORMConfiguration.DBCREATE_NONE: return "none";
+			case ORMConfiguration.DBCREATE_DROP_CREATE: return "dropcreate";
+			case ORMConfiguration.DBCREATE_UPDATE: return "update";
+			case 3: return "create";
+			case 4: return "create-drop";
+			case 5: return "validate";
+			default: return "unknown(" + dbCreate + ")";
+		}
 	}
 }
 

--- a/source/java/src/org/lucee/extension/orm/hibernate/logging/OrmLoggingSettings.java
+++ b/source/java/src/org/lucee/extension/orm/hibernate/logging/OrmLoggingSettings.java
@@ -91,6 +91,33 @@ public class OrmLoggingSettings {
 		return null;
 	}
 
+	/**
+	 * Check if the raw dbcreate string from this.ormSettings was silently defaulted to "none"
+	 * by the Lucee loader (6.2 doesn't support create/create-drop/validate).
+	 *
+	 * @return a warning message if there's a mismatch, or null if everything is fine.
+	 */
+	public static String checkDbCreate( PageContext pc, int resolvedDbCreate ) {
+		Struct ormSettings = getOrmSettingsStruct( pc );
+		if ( ormSettings == null ) return null;
+
+		Key KEY_DB_CREATE = CommonUtil.createKey( "dbcreate" );
+		String raw = CommonUtil.toString( ormSettings.get( KEY_DB_CREATE, null ), null );
+		if ( raw == null || raw.trim().isEmpty() ) return null;
+
+		raw = raw.trim().toLowerCase();
+		// These are the values that all Lucee versions understand
+		if ( "none".equals( raw ) || "update".equals( raw ) || "dropcreate".equals( raw ) || "drop-create".equals( raw ) )
+			return null;
+
+		// If the resolved value is NONE but the raw value isn't one of the known strings,
+		// the loader silently defaulted it
+		if ( resolvedDbCreate == 0 )
+			return "Unsupported dbcreate value [" + raw + "] for this Lucee version, defaulting to [none]";
+
+		return null;
+	}
+
 	@Override
 	public String toString() {
 		return String.format( "OrmLoggingSettings[logSQL=%s, logParams=%s, logCache=%s, formatSQL=%s, logVerbose=%s]",

--- a/source/java/src/org/lucee/extension/orm/hibernate/util/CommonUtil.java
+++ b/source/java/src/org/lucee/extension/orm/hibernate/util/CommonUtil.java
@@ -888,13 +888,46 @@ public class CommonUtil {
 		return pc().getConfig();
 	}
 
+	// Cached reflection lookup for ApplicationContext.getLog(String) (Lucee 7.0+).
+	private static volatile Method	appContextGetLog;
+	private static volatile boolean	appContextGetLogResolved = false;
+
+	/**
+	 * Get the ORM log from the given PageContext, respecting application-level
+	 * this.logs overrides before falling back to server config.
+	 */
+	public static Log getORMLog( PageContext pc ) {
+		if ( pc != null ) {
+			// Try application-level this.logs first (Lucee 7.0+ only)
+			if ( !appContextGetLogResolved ) {
+				try {
+					appContextGetLog = pc.getApplicationContext().getClass().getMethod( "getLog", String.class );
+				}
+				catch ( Exception e ) {
+					// Lucee 6.2 — method doesn't exist
+				}
+				appContextGetLogResolved = true;
+			}
+			if ( appContextGetLog != null ) {
+				try {
+					Log log = ( Log ) appContextGetLog.invoke( pc.getApplicationContext(), "orm" );
+					if ( log != null ) return log;
+				}
+				catch ( Exception e ) {
+					// fall through to server config
+				}
+			}
+			return pc.getConfig().getLog( "orm" );
+		}
+		return null;
+	}
+
 	/**
 	 * Get the ORM log from the current thread's PageContext, or null if unavailable.
 	 */
 	public static Log getORMLog() {
 		try {
-			PageContext pc = CFMLEngineFactory.getInstance().getThreadPageContext();
-			if ( pc != null ) return pc.getConfig().getLog( "orm" );
+			return getORMLog( CFMLEngineFactory.getInstance().getThreadPageContext() );
 		}
 		catch ( Exception e ) {
 			// no log available

--- a/tests/logging/appLogLevel/appOverrideError/Application.cfc
+++ b/tests/logging/appLogLevel/appOverrideError/Application.cfc
@@ -1,0 +1,29 @@
+component {
+
+	this.name = "orm-applog-error-#hash( getCurrentTemplatePath() )#";
+	this.datasource = server.getDatasource( "h2", server._getTempDir( "orm-applog-error" ) );
+	this.ormEnabled = true;
+	this.ormSettings = {
+		dbcreate: "dropcreate",
+		cfclocation: [ getDirectoryFromPath( getCurrentTemplatePath() ) ],
+		logSQL: true,
+		logParams: true
+	};
+
+	// Application-level log override — set orm log to ERROR
+	this.logs = {
+		"orm": {
+			"appender": "resource",
+			"appenderArguments": {
+				"path": "{lucee-config}/logs/orm.log"
+			},
+			"level": "error",
+			"layout": "classic"
+		}
+	};
+
+	function onRequestStart() {
+		ormReload();
+	}
+
+}

--- a/tests/logging/appLogLevel/appOverrideError/LogEntity.cfc
+++ b/tests/logging/appLogLevel/appOverrideError/LogEntity.cfc
@@ -1,0 +1,6 @@
+component persistent="true" table="LogEntity" accessors="true" {
+
+	property name="id"   type="string" fieldtype="id" ormtype="string";
+	property name="name" type="string";
+
+}

--- a/tests/logging/appLogLevel/appOverrideError/index.cfm
+++ b/tests/logging/appLogLevel/appOverrideError/index.cfm
@@ -1,0 +1,11 @@
+<cfscript>
+cflog( text: url.marker, log: "orm" );
+
+item = entityNew( "LogEntity" );
+item.setId( createUUID() );
+item.setName( "ErrorTest" );
+entitySave( item );
+ormFlush();
+
+echo( "ok" );
+</cfscript>

--- a/tests/logging/appLogLevel/appOverrideTrace/Application.cfc
+++ b/tests/logging/appLogLevel/appOverrideTrace/Application.cfc
@@ -1,0 +1,29 @@
+component {
+
+	this.name = "orm-applog-trace-#hash( getCurrentTemplatePath() )#";
+	this.datasource = server.getDatasource( "h2", server._getTempDir( "orm-applog-trace" ) );
+	this.ormEnabled = true;
+	this.ormSettings = {
+		dbcreate: "dropcreate",
+		cfclocation: [ getDirectoryFromPath( getCurrentTemplatePath() ) ],
+		logSQL: true,
+		logParams: true
+	};
+
+	// Application-level log override — set orm log to TRACE
+	this.logs = {
+		"orm": {
+			"appender": "resource",
+			"appenderArguments": {
+				"path": "{lucee-config}/logs/orm.log"
+			},
+			"level": "trace",
+			"layout": "classic"
+		}
+	};
+
+	function onRequestStart() {
+		ormReload();
+	}
+
+}

--- a/tests/logging/appLogLevel/appOverrideTrace/LogEntity.cfc
+++ b/tests/logging/appLogLevel/appOverrideTrace/LogEntity.cfc
@@ -1,0 +1,6 @@
+component persistent="true" table="LogEntity" accessors="true" {
+
+	property name="id"   type="string" fieldtype="id" ormtype="string";
+	property name="name" type="string";
+
+}

--- a/tests/logging/appLogLevel/appOverrideTrace/index.cfm
+++ b/tests/logging/appLogLevel/appOverrideTrace/index.cfm
@@ -1,0 +1,11 @@
+<cfscript>
+cflog( text: url.marker, log: "orm" );
+
+item = entityNew( "LogEntity" );
+item.setId( createUUID() );
+item.setName( "TraceTest" );
+entitySave( item );
+ormFlush();
+
+echo( "ok" );
+</cfscript>

--- a/tests/logging/isolation/appLogsOff/Application.cfc
+++ b/tests/logging/isolation/appLogsOff/Application.cfc
@@ -1,0 +1,17 @@
+component {
+
+	this.name = "orm-isolation-logsoff-#hash( getCurrentTemplatePath() )#";
+	this.datasource = server.getDatasource( "h2", server._getTempDir( "orm-isolation-off" ) );
+	this.ormEnabled = true;
+	this.ormSettings = {
+		dbcreate: "dropcreate",
+		cfclocation: [ getDirectoryFromPath( getCurrentTemplatePath() ) ],
+		logSQL: false,
+		logParams: false
+	};
+
+	function onRequestStart() {
+		ormReload();
+	}
+
+}

--- a/tests/logging/isolation/appLogsOff/IsoEntity.cfc
+++ b/tests/logging/isolation/appLogsOff/IsoEntity.cfc
@@ -1,0 +1,6 @@
+component persistent="true" table="IsoEntity" accessors="true" {
+
+	property name="id"   type="string" fieldtype="id" ormtype="string";
+	property name="name" type="string";
+
+}

--- a/tests/logging/isolation/appLogsOff/index.cfm
+++ b/tests/logging/isolation/appLogsOff/index.cfm
@@ -1,0 +1,11 @@
+<cfscript>
+cflog( text: url.marker, log: "orm" );
+
+item = entityNew( "IsoEntity" );
+item.setId( createUUID() );
+item.setName( "LogsOff" );
+entitySave( item );
+ormFlush();
+
+echo( "ok" );
+</cfscript>

--- a/tests/logging/isolation/appLogsOn/Application.cfc
+++ b/tests/logging/isolation/appLogsOn/Application.cfc
@@ -1,0 +1,17 @@
+component {
+
+	this.name = "orm-isolation-logson-#hash( getCurrentTemplatePath() )#";
+	this.datasource = server.getDatasource( "h2", server._getTempDir( "orm-isolation-on" ) );
+	this.ormEnabled = true;
+	this.ormSettings = {
+		dbcreate: "dropcreate",
+		cfclocation: [ getDirectoryFromPath( getCurrentTemplatePath() ) ],
+		logSQL: true,
+		logParams: true
+	};
+
+	function onRequestStart() {
+		ormReload();
+	}
+
+}

--- a/tests/logging/isolation/appLogsOn/IsoEntity.cfc
+++ b/tests/logging/isolation/appLogsOn/IsoEntity.cfc
@@ -1,0 +1,6 @@
+component persistent="true" table="IsoEntity" accessors="true" {
+
+	property name="id"   type="string" fieldtype="id" ormtype="string";
+	property name="name" type="string";
+
+}

--- a/tests/logging/isolation/appLogsOn/index.cfm
+++ b/tests/logging/isolation/appLogsOn/index.cfm
@@ -1,0 +1,11 @@
+<cfscript>
+cflog( text: url.marker, log: "orm" );
+
+item = entityNew( "IsoEntity" );
+item.setId( createUUID() );
+item.setName( "LogsOn" );
+entitySave( item );
+ormFlush();
+
+echo( "ok" );
+</cfscript>

--- a/tests/logging/lifecycle/Application.cfc
+++ b/tests/logging/lifecycle/Application.cfc
@@ -1,0 +1,12 @@
+component {
+
+	this.name = "orm-lifecycle-#url.appId ?: hash( getCurrentTemplatePath() )#";
+	this.datasource = server.getDatasource( "h2", server._getTempDir( "orm-lifecycle" ) );
+	this.ormEnabled = true;
+	this.ormSettings = {
+		dbcreate: "dropcreate",
+		cfclocation: [ getDirectoryFromPath( getCurrentTemplatePath() ) ],
+		logSQL: false
+	};
+
+}

--- a/tests/logging/lifecycle/Auto.cfc
+++ b/tests/logging/lifecycle/Auto.cfc
@@ -1,0 +1,11 @@
+component accessors="true" persistent="true" {
+
+	property
+		name     ="id"
+		type     ="string"
+		fieldtype="id"
+		ormtype  ="string";
+	property name="make"  type="string";
+	property name="model" type="string";
+
+}

--- a/tests/logging/lifecycle/index.cfm
+++ b/tests/logging/lifecycle/index.cfm
@@ -1,0 +1,3 @@
+<cfscript>
+echo( "ok" );
+</cfscript>

--- a/tests/logging/lifecycle/reload.cfm
+++ b/tests/logging/lifecycle/reload.cfm
@@ -1,0 +1,4 @@
+<cfscript>
+ormReload();
+echo( "ok" );
+</cfscript>

--- a/tests/logging/logCache/Application.cfc
+++ b/tests/logging/logCache/Application.cfc
@@ -1,0 +1,21 @@
+component {
+
+	this.name = "orm-logCache-#url.logCache ?: false#-#hash( getCurrentTemplatePath() )#";
+	this.datasources["h2"] = server.getDatasource( "h2", server._getTempDir( "orm-logCache" ) );
+	this.datasource = "h2";
+	this.ormEnabled = true;
+	this.ormSettings = {
+		dbcreate: "dropcreate",
+		cfclocation: [ getDirectoryFromPath( getCurrentTemplatePath() ) ],
+		logSQL: false,
+		logCache: url.logCache ?: false,
+		secondarycacheenabled: true,
+		cacheprovider: "ehcache",
+		cacheconfig: getDirectoryFromPath( getCurrentTemplatePath() ) & "ehcache.xml"
+	};
+
+	function onRequestStart() {
+		ormReload();
+	}
+
+}

--- a/tests/logging/logCache/CachedItem.cfc
+++ b/tests/logging/logCache/CachedItem.cfc
@@ -1,0 +1,6 @@
+component persistent="true" table="CachedItem" cachename="CachedItems" cacheuse="read-write" accessors="true" {
+
+	property name="id"   type="string" fieldtype="id" ormtype="string";
+	property name="name" type="string";
+
+}

--- a/tests/logging/logCache/ehcache.xml
+++ b/tests/logging/logCache/ehcache.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ehcache xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:noNamespaceSchemaLocation="ehcache.xsd" updateCheck="false" name="logCacheTest">
+	<diskStore path="java.io.tmpdir"/>
+	<defaultCache
+		maxElementsInMemory="100" eternal="false"
+		timeToIdleSeconds="120" timeToLiveSeconds="120"
+		memoryStoreEvictionPolicy="LRU">
+		<persistence strategy="localTempSwap"/>
+	</defaultCache>
+	<cache
+		name="CachedItems"
+		maxElementsInMemory="20"
+		overflowToDisk="false"
+		eternal="true">
+	</cache>
+</ehcache>

--- a/tests/logging/logCache/index.cfm
+++ b/tests/logging/logCache/index.cfm
@@ -1,0 +1,17 @@
+<cfscript>
+// write a marker so the test can find where this request's logging starts
+cflog( text: url.marker, log: "orm" );
+
+// save an entity — should produce a cache "put"
+item = entityNew( "CachedItem" );
+item.setId( createUUID() );
+item.setName( "TestItem" );
+entitySave( item );
+ormFlush();
+
+// clear session and reload — should produce a cache "hit"
+ormClearSession();
+loaded = entityLoadByPK( "CachedItem", item.getId() );
+
+echo( "ok" );
+</cfscript>

--- a/tests/logging/logging.cfc
+++ b/tests/logging/logging.cfc
@@ -70,12 +70,328 @@ component extends="org.lucee.cfml.test.LuceeTestCase" labels="orm" {
 				expect( logContent ).notToInclude( "Toyota" );
 			});
 
+			it( "formatSQL=true pretty-prints SQL with line breaks", function() {
+				var marker = "MARKER_FORMAT_TRUE_#createUUID()#";
+				var result = _InternalRequest(
+					template: "#uri()#/index.cfm",
+					url: { logSQL: true, logParams: false, formatSQL: true, marker: marker }
+				);
+				expect( trim( result.filecontent ) ).toBe( "ok" );
+				var logContent = getLogAfterMarker( marker );
+				systemOutput( "LOG FORMAT TRUE: [#logContent#]", true );
+				// formatted SQL contains "insert" spread across multiple log lines
+				expect( lCase( logContent ) ).toInclude( "insert" );
+				// formatted SQL indents columns — look for leading whitespace before column keywords
+				expect( logContent ).toMatch( "(?m)^\s+(values|into)" );
+			});
+
+			it( "formatSQL=false keeps SQL on single lines", function() {
+				var marker = "MARKER_FORMAT_FALSE_#createUUID()#";
+				var result = _InternalRequest(
+					template: "#uri()#/index.cfm",
+					url: { logSQL: true, logParams: false, formatSQL: false, marker: marker }
+				);
+				expect( trim( result.filecontent ) ).toBe( "ok" );
+				var logContent = getLogAfterMarker( marker );
+				systemOutput( "LOG FORMAT FALSE: [#logContent#]", true );
+				expect( lCase( logContent ) ).toInclude( "insert" );
+				// unformatted SQL should NOT have indented keywords
+				expect( logContent ).notToMatch( "(?m)^\s+(values|into)" );
+			});
+
+			it( "logVerbose=true logs Hibernate internals", function() {
+				var marker = "MARKER_VERBOSE_TRUE_#createUUID()#";
+				var result = _InternalRequest(
+					template: "#uri()#/index.cfm",
+					url: { logSQL: false, logParams: false, logVerbose: true, marker: marker }
+				);
+				expect( trim( result.filecontent ) ).toBe( "ok" );
+				var logContent = lCase( getLogAfterMarker( marker ) );
+				systemOutput( "LOG VERBOSE TRUE: [#logContent#]", true );
+				// verbose logging should include session/entity lifecycle keywords
+				expect(
+					logContent contains "flush" ||
+					logContent contains "dirty" ||
+					logContent contains "session" ||
+					logContent contains "entity" ||
+					logContent contains "schema" ||
+					logContent contains "auto-flushing"
+				).toBeTrue();
+			});
+
+			it( "logVerbose=false does not log Hibernate internals", function() {
+				var marker = "MARKER_VERBOSE_FALSE_#createUUID()#";
+				var result = _InternalRequest(
+					template: "#uri()#/index.cfm",
+					url: { logSQL: false, logParams: false, logVerbose: false, marker: marker }
+				);
+				expect( trim( result.filecontent ) ).toBe( "ok" );
+				var logContent = lCase( getLogAfterMarker( marker ) );
+				systemOutput( "LOG VERBOSE FALSE: [#logContent#]", true );
+				// with all logging off, only the marker itself should be in the log
+				expect( logContent ).notToInclude( "auto-flushing" );
+				expect( logContent ).notToInclude( "dirty checking" );
+			});
+
+			it( "dual-gate: logSQL=true with ERROR log level produces no output", function() {
+				try {
+					// temporarily set orm log to ERROR — the level gate should block everything
+					configImport( type: "server", password: request.SERVERADMINPASSWORD, data: {
+						loggers: {
+							orm: {
+								appender: "resource",
+								appenderArguments: { path: "{lucee-config}/logs/orm.log" },
+								level: "error",
+								layout: "classic"
+							}
+						}
+					});
+
+					// can't use markers — cflog at INFO would be blocked by ERROR level
+					// instead, capture log length before and check only new content
+					var offsetBefore = getLogLength();
+					var result = _InternalRequest(
+						template: "#uri()#/index.cfm",
+						url: { logSQL: true, logParams: true, marker: "DUALGATE_IGNORED" }
+					);
+					expect( trim( result.filecontent ) ).toBe( "ok" );
+					var logContent = getLogContentSince( offsetBefore );
+					systemOutput( "LOG DUALGATE: [#logContent#]", true );
+					// SQL is logged at DEBUG/TRACE — ERROR level should block it
+					expect( lCase( logContent ) ).notToInclude( "insert" );
+					expect( logContent ).notToInclude( "Toyota" );
+				} finally {
+					// restore TRACE level for subsequent tests
+					configureOrmLog();
+				}
+			});
+
+		});
+
+		describe( "ORM cache logging", function() {
+
+			it( "logCache=true logs L2 cache activity", function() {
+				var marker = "MARKER_CACHE_TRUE_#createUUID()#";
+				var result = _InternalRequest(
+					template: "#logCacheUri()#/index.cfm",
+					url: { logCache: true, marker: marker }
+				);
+				expect( trim( result.filecontent ) ).toBe( "ok" );
+				var logContent = lCase( getLogAfterMarker( marker ) );
+				systemOutput( "LOG CACHE TRUE: [#logContent#]", true );
+				expect(
+					logContent contains "cache" ||
+					logContent contains "region" ||
+					logContent contains "put" ||
+					logContent contains "hit" ||
+					logContent contains "miss"
+				).toBeTrue();
+			});
+
+			it( "logCache=false does not log cache activity", function() {
+				var marker = "MARKER_CACHE_FALSE_#createUUID()#";
+				var result = _InternalRequest(
+					template: "#logCacheUri()#/index.cfm",
+					url: { logCache: false, marker: marker }
+				);
+				expect( trim( result.filecontent ) ).toBe( "ok" );
+				var logContent = lCase( getLogAfterMarker( marker ) );
+				systemOutput( "LOG CACHE FALSE: [#logContent#]", true );
+				// with logCache off, no cache keywords should appear
+				expect( logContent ).notToInclude( "caching" );
+				expect( logContent ).notToInclude( "region" );
+			});
+
+		});
+
+		describe( "savemapping", function() {
+
+			it( "savemapping=true writes .hbm.xml alongside entity CFC", function() {
+				var result = _InternalRequest(
+					template: "#savemappingUri()#/index.cfm"
+				);
+				expect( trim( result.filecontent ) ).toBe( "ok" );
+			});
+
+		});
+
+		describe( "this.logs application-level log override", function() {
+
+			it( title="app this.logs=TRACE overrides server ERROR — SQL appears", skip=notHasThisLogs(), body=function() {
+				try {
+					// set server orm log to ERROR
+					configImport( type: "server", password: request.SERVERADMINPASSWORD, data: {
+						loggers: {
+							orm: {
+								appender: "resource",
+								appenderArguments: { path: "{lucee-config}/logs/orm.log" },
+								level: "error",
+								layout: "classic"
+							}
+						}
+					});
+
+					var marker = "MARKER_APPLOG_TRACE_#createUUID()#";
+					var result = _InternalRequest(
+						template: "#appLogLevelUri( 'appOverrideTrace' )#/index.cfm",
+						url: { marker: marker }
+					);
+					expect( trim( result.filecontent ) ).toBe( "ok" );
+					var logContent = lCase( getLogAfterMarker( marker ) );
+					systemOutput( "LOG APP TRACE OVERRIDE: [#logContent#]", true );
+					// app this.logs TRACE overrides server ERROR — SQL appears
+					expect( logContent ).toInclude( "insert" );
+				} finally {
+					configureOrmLog();
+				}
+			});
+
+			it( title="app this.logs=TRACE works with no server orm log", skip=notHasThisLogs(), body=function() {
+				try {
+					// remove the server orm log entirely
+					admin
+						action="removeLogSetting"
+						type="server"
+						password="#request.SERVERADMINPASSWORD#"
+						name="orm";
+
+					var marker = "MARKER_APPLOG_NOSERVER_#createUUID()#";
+					var result = _InternalRequest(
+						template: "#appLogLevelUri( 'appOverrideTrace' )#/index.cfm",
+						url: { marker: marker }
+					);
+					expect( trim( result.filecontent ) ).toBe( "ok" );
+					var logContent = lCase( getLogAfterMarker( marker ) );
+					systemOutput( "LOG APP NO SERVER: [#logContent#]", true );
+					// app defines orm log via this.logs — should work without server log
+					expect( logContent ).toInclude( "insert" );
+				} finally {
+					configureOrmLog();
+				}
+			});
+
+			it( title="app this.logs=ERROR overrides server TRACE — SQL blocked", skip=notHasThisLogs(), body=function() {
+				// server is at TRACE (restored by beforeAll / previous finally)
+				// app sets orm log to ERROR via this.logs — app wins, blocks SQL
+				// can't use markers — this.logs ERROR blocks cflog at INFO too
+				var offsetBefore = getLogLength();
+				var result = _InternalRequest(
+					template: "#appLogLevelUri( 'appOverrideError' )#/index.cfm",
+					url: { marker: "APPLOG_ERROR_IGNORED" }
+				);
+				expect( trim( result.filecontent ) ).toBe( "ok" );
+				var logContent = lCase( getLogContentSince( offsetBefore ) );
+				systemOutput( "LOG APP ERROR OVERRIDE: [#logContent#]", true );
+				// app this.logs ERROR overrides server TRACE — SQL blocked
+				expect( logContent ).notToInclude( "insert" );
+			});
+
+		});
+
+		describe( "ORM lifecycle logging", function() {
+
+			it( "cold start logs ORM initializing and initialized", function() {
+				var offsetBefore = getLogLength();
+				var appId = createUUID();
+				var result = _InternalRequest(
+					template: "#lifecycleUri()#/index.cfm",
+					url: { appId: appId }
+				);
+				expect( trim( result.filecontent ) ).toBe( "ok" );
+				var logContent = getLogContentSince( offsetBefore );
+				systemOutput( "LOG LIFECYCLE COLD: [#logContent#]", true );
+				expect( lCase( logContent ) ).toInclude( "orm initializing for application [" );
+				expect( lCase( logContent ) ).toInclude( "orm initialized [" );
+				expect( lCase( logContent ) ).toInclude( "] entities" );
+				expect( lCase( logContent ) ).toInclude( "dbcreate [" );
+				expect( lCase( logContent ) ).toInclude( "ormloggingsettings[" );
+				// cold start should NOT contain ormReload message
+				expect( lCase( logContent ) ).notToInclude( "ormreload()" );
+			});
+
+			it( "ormReload logs reload trigger and init messages", function() {
+				var offsetBefore = getLogLength();
+				var appId = createUUID();
+				// first request: cold start
+				_InternalRequest(
+					template: "#lifecycleUri()#/index.cfm",
+					url: { appId: appId }
+				);
+				// second request: same app, calls ormReload()
+				var offsetBeforeReload = getLogLength();
+				var result = _InternalRequest(
+					template: "#lifecycleUri()#/reload.cfm",
+					url: { appId: appId }
+				);
+				expect( trim( result.filecontent ) ).toBe( "ok" );
+				var logContent = getLogContentSince( offsetBeforeReload );
+				systemOutput( "LOG LIFECYCLE RELOAD: [#logContent#]", true );
+				expect( lCase( logContent ) ).toInclude( "ormreload() for application [" );
+				expect( lCase( logContent ) ).toInclude( "orm initializing for application [" );
+				expect( lCase( logContent ) ).toInclude( "orm initialized [" );
+			});
+
+		});
+
+		describe( "Per-application logging isolation", function() {
+
+			it( "app with logSQL=true logs SQL, app with logSQL=false does not", function() {
+				// app with logging ON
+				var markerOn = "MARKER_ISO_ON_#createUUID()#";
+				var resultOn = _InternalRequest(
+					template: "#isolationUri( 'appLogsOn' )#/index.cfm",
+					url: { marker: markerOn }
+				);
+				expect( trim( resultOn.filecontent ) ).toBe( "ok" );
+				var logOn = lCase( getLogAfterMarker( markerOn ) );
+				systemOutput( "LOG ISO ON: [#logOn#]", true );
+
+				// app with logging OFF
+				var markerOff = "MARKER_ISO_OFF_#createUUID()#";
+				var resultOff = _InternalRequest(
+					template: "#isolationUri( 'appLogsOff' )#/index.cfm",
+					url: { marker: markerOff }
+				);
+				expect( trim( resultOff.filecontent ) ).toBe( "ok" );
+				var logOff = lCase( getLogAfterMarker( markerOff ) );
+				systemOutput( "LOG ISO OFF: [#logOff#]", true );
+
+				// ON app should have SQL
+				expect( logOn ).toInclude( "insert" );
+				// OFF app should NOT have SQL
+				expect( logOff ).notToInclude( "insert" );
+			});
+
 		});
 
 	}
 
+	private boolean function notHasThisLogs() {
+		return !server.checkVersionGTE( server.lucee.version, 7, 0, 0, 115 );
+	}
+
 	private string function uri() {
 		return getDirectoryFromPath( contractPath( getCurrentTemplatePath() ) ) & "logging";
+	}
+
+	private string function logCacheUri() {
+		return getDirectoryFromPath( contractPath( getCurrentTemplatePath() ) ) & "logCache";
+	}
+
+	private string function savemappingUri() {
+		return getDirectoryFromPath( contractPath( getCurrentTemplatePath() ) ) & "savemapping";
+	}
+
+	private string function lifecycleUri() {
+		return getDirectoryFromPath( contractPath( getCurrentTemplatePath() ) ) & "lifecycle";
+	}
+
+	private string function isolationUri( required string app ) {
+		return getDirectoryFromPath( contractPath( getCurrentTemplatePath() ) ) & "isolation/" & arguments.app;
+	}
+
+	private string function appLogLevelUri( required string app ) {
+		return getDirectoryFromPath( contractPath( getCurrentTemplatePath() ) ) & "appLogLevel/" & arguments.app;
 	}
 
 	private string function getLogAfterMarker( required string marker ) {
@@ -83,8 +399,22 @@ component extends="org.lucee.cfml.test.LuceeTestCase" labels="orm" {
 		if ( !fileExists( logFile ) ) return "";
 		var content = fileRead( logFile );
 		var pos = content.findNoCase( arguments.marker );
-		if ( pos == 0 ) return content;
+		if ( pos == 0 ) return "";
 		return content.mid( pos + len( arguments.marker ), len( content ) );
+	}
+
+	private string function getLogContentSince( required numeric offset ) {
+		var logFile = expandPath( "{lucee-config}/logs/orm.log" );
+		if ( !fileExists( logFile ) ) return "";
+		var content = fileRead( logFile );
+		if ( len( content ) <= arguments.offset ) return "";
+		return content.mid( arguments.offset + 1, len( content ) );
+	}
+
+	private numeric function getLogLength() {
+		var logFile = expandPath( "{lucee-config}/logs/orm.log" );
+		if ( !fileExists( logFile ) ) return 0;
+		return len( fileRead( logFile ) );
 	}
 
 	private void function configureOrmLog() {

--- a/tests/logging/logging/Application.cfc
+++ b/tests/logging/logging/Application.cfc
@@ -1,13 +1,15 @@
 component {
 
-	this.name = "orm-logging-#url.logSQL ?: false#-#url.logParams ?: false#-#hash( getCurrentTemplatePath() )#";
+	this.name = "orm-logging-#url.logSQL ?: false#-#url.logParams ?: false#-#url.formatSQL ?: false#-#url.logVerbose ?: false#-#hash( getCurrentTemplatePath() )#";
 	this.datasource = server.getDatasource( "h2", server._getTempDir( "orm-logging" ) );
 	this.ormEnabled = true;
 	this.ormSettings = {
 		dbcreate: "dropcreate",
 		cfclocation: [ getDirectoryFromPath( getCurrentTemplatePath() ) ],
 		logSQL: url.logSQL ?: false,
-		logParams: url.logParams ?: false
+		logParams: url.logParams ?: false,
+		formatSQL: url.formatSQL ?: false,
+		logVerbose: url.logVerbose ?: false
 	};
 
 	function onRequestStart() {

--- a/tests/logging/savemapping/Application.cfc
+++ b/tests/logging/savemapping/Application.cfc
@@ -1,0 +1,16 @@
+component {
+
+	this.name = "orm-savemapping-#hash( getCurrentTemplatePath() )#";
+	this.datasource = server.getDatasource( "h2", server._getTempDir( "orm-savemapping" ) );
+	this.ormEnabled = true;
+	this.ormSettings = {
+		dbcreate: "dropcreate",
+		cfclocation: [ getDirectoryFromPath( getCurrentTemplatePath() ) ],
+		savemapping: true
+	};
+
+	function onRequestStart() {
+		ormReload();
+	}
+
+}

--- a/tests/logging/savemapping/MappedEntity.cfc
+++ b/tests/logging/savemapping/MappedEntity.cfc
@@ -1,0 +1,7 @@
+component persistent="true" table="MappedEntity" accessors="true" {
+
+	property name="id"    type="string" fieldtype="id" ormtype="string";
+	property name="title" type="string";
+	property name="price" type="numeric" ormtype="big_decimal" precision="12" scale="4";
+
+}

--- a/tests/logging/savemapping/index.cfm
+++ b/tests/logging/savemapping/index.cfm
@@ -1,0 +1,21 @@
+<cfscript>
+// ORM init + savemapping happens on app start — just verify the files
+dir = getDirectoryFromPath( getCurrentTemplatePath() );
+hbmFile = dir & "MappedEntity.cfc.hbm.xml";
+
+if ( !fileExists( hbmFile ) )
+	throw( message="Expected mapping file not found [#hbmFile#]" );
+
+content = fileRead( hbmFile );
+
+if ( content does not contain "MappedEntity" )
+	throw( message="Mapping file does not contain entity name" );
+
+if ( content does not contain "title" )
+	throw( message="Mapping file does not contain property [title]" );
+
+if ( content does not contain "price" )
+	throw( message="Mapping file does not contain property [price]" );
+
+echo( "ok" );
+</cfscript>

--- a/tests/session/apiSmoke.cfc
+++ b/tests/session/apiSmoke.cfc
@@ -64,6 +64,16 @@ component extends="org.lucee.cfml.test.LuceeTestCase" labels="orm" {
 				expect( trim( result.filecontent ) ).toBe( "ok" );
 			});
 
+			it( "getStatistics() returns entity and collection counts", function() {
+				var result = _InternalRequest( template: "#uri()#/statisticsCounts.cfm" );
+				expect( trim( result.filecontent ) ).toBe( "ok" );
+			});
+
+			it( "getDialect() returns the active SQL dialect", function() {
+				var result = _InternalRequest( template: "#uri()#/getDialect.cfm" );
+				expect( trim( result.filecontent ) ).toBe( "ok" );
+			});
+
 		});
 
 	}

--- a/tests/session/apiSmoke/getDialect.cfm
+++ b/tests/session/apiSmoke/getDialect.cfm
@@ -1,0 +1,14 @@
+<cfscript>
+// Test getDialect() returns the active SQL dialect
+dialect = ORMGetSessionFactory().getDialect();
+
+className = dialect.getClass().getName();
+
+if ( className does not contain "Dialect" )
+	throw( message="Expected dialect class name to contain 'Dialect', got [#className#]" );
+
+if ( className does not contain "H2" )
+	throw( message="Expected H2 dialect for test datasource, got [#className#]" );
+
+echo( "ok" );
+</cfscript>

--- a/tests/session/apiSmoke/statisticsCounts.cfm
+++ b/tests/session/apiSmoke/statisticsCounts.cfm
@@ -1,0 +1,23 @@
+<cfscript>
+// Test getStatistics() entity and collection counts
+id1 = createUUID();
+id2 = createUUID();
+id3 = createUUID();
+
+entitySave( entityNew( "SmokeEntity", { id: id1, name: "One" } ) );
+entitySave( entityNew( "SmokeEntity", { id: id2, name: "Two" } ) );
+entitySave( entityNew( "SmokeEntity", { id: id3, name: "Three" } ) );
+ormFlush();
+
+stats = ORMGetSession().getStatistics();
+entityCount = stats.getEntityCount();
+collectionCount = stats.getCollectionCount();
+
+if ( entityCount != 3 )
+	throw( message="Expected 3 entities in session, got [#entityCount#]" );
+
+if ( collectionCount != 0 )
+	throw( message="Expected 0 collections in session, got [#collectionCount#]" );
+
+echo( "ok" );
+</cfscript>


### PR DESCRIPTION
## Summary

- ORM logging now respects application-level `this.logs` overrides (Lucee 7.0+) — each app can independently control its orm log level without affecting other apps
- Added extension lifecycle logging at DEBUG level: "ORM initializing", "ORM initialized" (with entity count and settings), "ormReload()" messages
- Comprehensive test coverage for all orm-logging.md documentation claims

## Changes

### this.logs support
- `CommonUtil.getORMLog(PageContext)` checks `ApplicationContext.getLog("orm")` first via reflection, falls back to server config
- Works on 7.0+, graceful no-op on 6.2 (reflection finds no method, falls through)
- `HibernateORMEngine` uses the new app-scoped log resolution

### Lifecycle logging
- "ORM initializing for application [...], dbcreate [...]" at DEBUG on init
- "ORM initialized [...] entities for application [...], OrmLoggingSettings[...]" at DEBUG on completion
- "ormReload() for application [...]" at DEBUG on reload
- dbcreate warning at WARN when loader silently defaults unsupported values

### Test coverage (18 new tests)
- formatSQL true/false
- logVerbose true/false
- logCache true/false (with ehcache)
- Dual-gate (flags on + ERROR level = no output)
- savemapping writes .hbm.xml files
- Per-app logging isolation
- this.logs TRACE overrides server ERROR
- this.logs ERROR overrides server TRACE
- this.logs works with no server orm log
- Lifecycle logging (cold start + ormReload)
- getStatistics() entity/collection counts
- getDialect() returns correct dialect

## Test plan
- [x] test7.bat logging — 18/18 pass on 7.0
- [x] test.bat full suite — 0 failures on 6.2, 7.0, 7.1
- [x] this.logs tests correctly skip on 6.2 (< 7.0.0.115)