### PR TITLE
OOE-28 shade javax.validation-api for Lucee 7+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 5.6.15.14
+
+- [OOE-28](https://ortussolutions.atlassian.net/browse/OOE-28) — `NoClassDefFoundError: javax/validation/ValidatorFactory` on Lucee 7+. Lucee 7 exposes `jakarta.validation` via OSGi boot delegation, causing Hibernate's `BeanValidationIntegrator` to think Bean Validation is available — but `TypeSafeActivator` has hard `javax.validation` imports which then fail. Fixed by shading `javax.validation:validation-api` into the extension jar. This was masked locally because script-runner's `pom-jakarta.xml` was missing `jakarta.jakartaee-api`, making its classpath a subset of the real Lucee runtime
+
 ## 5.6.15.13
 
 ### Improvements

--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ Install via Lucee Admin, or pin in your environment:
 
 ```bash
 # Lucee 7.0+ (Maven coordinates, auto-updates to latest snapshot)
-LUCEE_EXTENSIONS=org.lucee:hibernate-extension:5.6.15.12-SNAPSHOT
+LUCEE_EXTENSIONS=org.lucee:hibernate-extension:5.6.15.14-SNAPSHOT
 
 # Lucee 6.2 (extension GUID, pinned version)
-LUCEE_EXTENSIONS=FAD1E8CB-4F45-4184-86359145767C29DE;version=5.6.15.12-SNAPSHOT
+LUCEE_EXTENSIONS=FAD1E8CB-4F45-4184-86359145767C29DE;version=5.6.15.14-SNAPSHOT
 ```
 
 ## History

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.lucee</groupId>
     <artifactId>hibernate-extension</artifactId>
-    <version>5.6.15.13-SNAPSHOT</version>
+    <version>5.6.15.14-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Hibernate Extension</name>
 
@@ -112,6 +112,15 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>1.7.36</version>
+        </dependency>
+
+        <!-- Bean Validation API (Hibernate 5.6's TypeSafeActivator has hard javax.validation
+             imports — Lucee 7+ exposes jakarta.validation via boot delegation, Hibernate
+             thinks BV is available, then fails loading the javax classes) -->
+        <dependency>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
+            <version>1.1.0.Final</version>
         </dependency>
 
         <!-- JAXB (needed for Hibernate XML mapping) -->


### PR DESCRIPTION
## Summary

- Shade `javax.validation:validation-api:1.1.0.Final` into the extension fat jar
- Fixes `NoClassDefFoundError: javax/validation/ValidatorFactory` on Lucee 7+

Lucee 7 exposes `jakarta.validation` via OSGi boot delegation (`default.properties`), causing Hibernate 5.6's `BeanValidationIntegrator` to think Bean Validation is available. It then loads `TypeSafeActivator` which has hard `javax.validation.*` imports — those classes aren't on the classpath, so it blows up.

This was masked locally because script-runner's `pom-jakarta.xml` was missing `jakarta.jakartaee-api`, making its classpath a subset of the real Lucee runtime. That's been fixed separately in lucee/script-runner@85a4d56.

## Test plan

- All tests pass on 6.2, 7.0, 7.1 (with the script-runner classpath fix applied)
- Verified `javax.validation` classes are included in the shaded jar
- Verified without this fix, 7.0 and 7.1 fail with 432/434 errors