### PR TITLE
LDEV-6267 relocate shaded ehcache classes to prevent OSGi ClassCastException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 5.6.15.15
+
+- [LDEV-6267](https://luceeserver.atlassian.net/browse/LDEV-6267) — Relocate shaded `net.sf.ehcache` classes to `org.lucee.extension.orm.hibernate.shaded.net.sf.ehcache` to prevent `ClassCastException` when the ehcache Lucee extension is also installed. Both extensions loaded the same ehcache classes from different OSGi `BundleClassLoader` instances
+
 ## 5.6.15.14
 
 - [OOE-28](https://ortussolutions.atlassian.net/browse/OOE-28) — `NoClassDefFoundError: javax/validation/ValidatorFactory` on Lucee 7+. Lucee 7 exposes `jakarta.validation` via OSGi boot delegation, causing Hibernate's `BeanValidationIntegrator` to think Bean Validation is available — but `TypeSafeActivator` has hard `javax.validation` imports which then fail. Fixed by shading `javax.validation:validation-api` into the extension jar. This was masked locally because script-runner's `pom-jakarta.xml` was missing `jakarta.jakartaee-api`, making its classpath a subset of the real Lucee runtime

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.lucee</groupId>
     <artifactId>hibernate-extension</artifactId>
-    <version>5.6.15.14-SNAPSHOT</version>
+    <version>5.6.15.15-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Hibernate Extension</name>
 
@@ -286,6 +286,16 @@
                                     </manifestEntries>
                                 </transformer>
                             </transformers>
+                            <!-- Relocate ehcache classes to a private namespace so they never
+                                 conflict with the ehcache Lucee extension's OSGi-exported copy.
+                                 Without this, both bundles have net.sf.ehcache.* classes loaded by
+                                 different BundleClassLoaders → ClassCastException. -->
+                            <relocations>
+                                <relocation>
+                                    <pattern>net.sf.ehcache</pattern>
+                                    <shadedPattern>org.lucee.extension.orm.hibernate.shaded.net.sf.ehcache</shadedPattern>
+                                </relocation>
+                            </relocations>
                             <createDependencyReducedPom>false</createDependencyReducedPom>
                         </configuration>
                     </execution>


### PR DESCRIPTION
## Summary

- Relocate `net.sf.ehcache.*` to `org.lucee.extension.orm.hibernate.shaded.net.sf.ehcache.*` via maven-shade-plugin relocation
- Prevents `ClassCastException` when ehcache Lucee extension is also installed (both bundles loaded the same classes from different OSGi BundleClassLoaders)
- Hibernate extension stays fully self-contained — no dependency on the ehcache extension

## Test plan

- [x] `test7.bat` — 0 failures, 0 errors (Lucee 7.0)
- [x] `test-ehcache039.bat` — 0 failures, 0 errors on 6.2, 7.0, 7.1 with `org.lucee:ehcache-extension:2.10.0.39` (the problematic dual-jar build) installed alongside