### PR TITLE
LDEV-1697 tighten dotted cfc resolution + contextual throw with source CFC/property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 5.6.15.17
 
 - [LDEV-6340](https://luceeserver.atlassian.net/browse/LDEV-6340) — Entities extending a `mappedSuperClass="true"` parent no longer log `failed to resolve parent entity` warnings on every SessionFactory build. Mapped superclasses aren't entities, so "parent not registered" is the expected state, not an error
+- [LDEV-1697](https://luceeserver.atlassian.net/browse/LDEV-1697) — Tightened entity resolution for `cfc="ns.Name"` references: a dotted ref now requires the matching `/ns` mapping to be declared in the current application. Previously a silent simple-name fallback resolved any registered `Name` entity regardless of namespace — iteration-order-dependent (passed on Windows, failed on Linux). The new throw on unresolvable refs names the source CFC and property: `Cannot resolve entity reference [ns.Name] on property [foo] of [...]`. Matches ACF behaviour
 
 ## 5.6.15.16
 

--- a/source/java/src/org/lucee/extension/orm/hibernate/SessionFactoryData.java
+++ b/source/java/src/org/lucee/extension/orm/hibernate/SessionFactoryData.java
@@ -199,12 +199,6 @@ public class SessionFactoryData {
 			}
 		}
 
-		CFCInfo info = getCFC(name, null);
-		if (info != null) {
-			cfc = info.getCFC();
-			return unique ? (Component) cfc.duplicate(false) : cfc;
-		}
-
 		return defaultValue;
 	}
 
@@ -224,12 +218,11 @@ public class SessionFactoryData {
 			while (it2.hasNext()) {
 				cfc = it2.next();
 				names.add(cfc.getName());
-				if (HibernateUtil.isEntity(ormConf, cfc, cfcName, name)) // if(cfc.equalTo(name))
+				if (HibernateUtil.isEntity(ormConf, cfc, cfcName, name))
 					return unique ? (Component) cfc.duplicate(false) : cfc;
 			}
 		}
 		else {
-			// search cfcs
 			Iterator<Map<String, CFCInfo>> it = cfcs.values().iterator();
 			Map<String, CFCInfo> _cfcs;
 			while (it.hasNext()) {
@@ -238,16 +231,10 @@ public class SessionFactoryData {
 				while (_it.hasNext()) {
 					cfc = _it.next().getCFC();
 					names.add(cfc.getName());
-					if (HibernateUtil.isEntity(ormConf, cfc, cfcName, name)) // if(cfc.instanceOf(name))
+					if (HibernateUtil.isEntity(ormConf, cfc, cfcName, name))
 						return unique ? (Component) cfc.duplicate(false) : cfc;
 				}
 			}
-		}
-
-		CFCInfo info = getCFC(name, null);
-		if (info != null) {
-			cfc = info.getCFC();
-			return unique ? (Component) cfc.duplicate(false) : cfc;
 		}
 
 		throw ExceptionUtil.createException((ORMSession) null, null, "Entity [" + name + "] " + (Util.isEmpty(cfcName) ? "" : "with cfc name [" + cfcName + "] ")

--- a/source/java/src/org/lucee/extension/orm/hibernate/mapping/HBMCreator.java
+++ b/source/java/src/org/lucee/extension/orm/hibernate/mapping/HBMCreator.java
@@ -1532,7 +1532,13 @@ public class HBMCreator {
 
 			str = toString(cfc, prop, meta, "cfc", cfcRequired, data);
 			if (!Util.isEmpty(str, true)) {
-				Component _cfc = data.getEntityByCFCName(str, false);
+				Component _cfc = data.getEntityByCFCName(str, false, null);
+				if (_cfc == null) {
+					throw ExceptionUtil.createException( data, cfc,
+						"Cannot resolve entity reference [" + str + "] on property [" + prop.getName()
+							+ "] of [" + cfc.getPageSource().getComponentName() + "]",
+						null );
+				}
 				str = HibernateCaster.getEntityName(_cfc);
 				el.setAttribute("entity-name", str);
 			}

--- a/tests/mapping/cfcLocationRecursion.cfc
+++ b/tests/mapping/cfcLocationRecursion.cfc
@@ -4,19 +4,29 @@ component extends="org.lucee.cfml.test.LuceeTestCase" labels="orm" {
 
 		describe( "ORM cfclocation recursion across nested Application.cfc", function() {
 
-			// Locks in current cross-engine behaviour: cfclocation recursion is
-			// blind to nested Application.cfc files. The parent app's recursive
-			// scan walks into ./child/entities/ and registers Foo in the parent
-			// SessionFactory, even though child/Application.cfc declares its own
-			// app.
-			//
-			// Both Lucee and ACF behave this way. If this test ever starts
-			// failing because Foo is unreachable from the parent SF, the
-			// recursion strategy has changed — a behavioural break shared apps
-			// may rely on. Re-evaluate before "fixing".
-			it( "parent cfclocation recurses into child Application.cfc dirs", function() {
+			// Parent's cfclocation recursion picks up sibling Application.cfc dirs
+			// (current cross-engine behaviour — both Lucee and ACF; see LDEV-1697
+			// tracker for Fix B rationale). Without the matching /childns mapping
+			// in the parent app, Foo's cfc="childns.Bar" ref is unresolvable and
+			// the SF build correctly throws with source context.
+			it( "without /childns mapping in parent, unresolvable dotted cfc ref throws with context", function() {
 				var template = "#uri()#/test.cfm";
-				var result = _InternalRequest( template: template );
+				var caught = "";
+				try {
+					_InternalRequest( template: template );
+					fail( "expected SF build to throw on unresolvable cfc=[childns.Bar]" );
+				} catch ( any e ) {
+					caught = e.message;
+				}
+				expect( caught ).toInclude( "Cannot resolve entity reference [childns.Bar]" );
+				expect( caught ).toInclude( "property [bar]" );
+			});
+
+			// When the parent app declares the matching /childns mapping, the same
+			// recursion-picked entities resolve correctly and entityNew works.
+			it( "with /childns mapping in parent, dotted cfc ref resolves and entityNew works", function() {
+				var template = "#uri()#/test.cfm";
+				var result = _InternalRequest( template: template, url: { withMapping: true } );
 				expect( trim( result.filecontent ) ).toBe( "ok" );
 			});
 

--- a/tests/mapping/cfcLocationRecursion/Application.cfc
+++ b/tests/mapping/cfcLocationRecursion/Application.cfc
@@ -1,11 +1,20 @@
 component {
-	this.name = "test-cfclocation-recursion-#hash( getCurrentTemplatePath() )#";
-	this.datasource = server.getDatasource( "h2", server._getTempDir( "orm-cfclocation-recursion" ) );
+	withMapping = structKeyExists( url, "withMapping" ) && url.withMapping;
+	this.name = "test-cfclocation-recursion-#hash( getCurrentTemplatePath() & withMapping )#";
+	this.datasource = server.getDatasource( "h2", server._getTempDir( "orm-cfclocation-recursion-#withMapping#" ) );
 	this.ormEnabled = true;
 	this.ormSettings = {
 		dbcreate: "dropcreate",
-		// Recurses into ./child/entities/, picking up entities that reference
-		// cfc="childns.Bar" — a mapping only the child Application.cfc declares.
+		// Parent's recursive cfclocation walks into ./child/entities/ and picks up
+		// Foo.cfc + Bar.cfc, even though child/Application.cfc owns that dir.
+		// Foo declares cfc="childns.Bar" — without the matching this.mappings entry
+		// in this parent app, that ref is unresolvable and the SF build correctly
+		// throws (see cfcLocationRecursion.cfc — first spec).
+		// When the spec passes url.withMapping=true, this app declares the matching
+		// /childns mapping below and the same setup resolves successfully.
 		cfclocation: [ getDirectoryFromPath( getCurrentTemplatePath() ) ]
 	};
+	if ( withMapping ) {
+		this.mappings = { "/childns" = getDirectoryFromPath( getCurrentTemplatePath() ) & "child/entities" };
+	}
 }


### PR DESCRIPTION
https://luceeserver.atlassian.net/browse/LDEV-1697

- Drop the silent simple-name `getCFC(name)` fallback in `SessionFactoryData.getEntityByCFCName` (both 2-arg and 3-arg variants). A dotted reference like `cfc="ns.Name"` now requires the matching `/ns` mapping in the current app — previously a registered `Name` entity in any namespace would resolve, iteration-order-dependent (passed Windows, failed Linux).
- `HBMCreator.setForeignEntityName` now uses the non-throwing 3-arg variant and throws contextual on null: `Cannot resolve entity reference [ns.Name] on property [foo] of [...]`. Names the source CFC + property so the misconfiguration is immediately diagnosable.
- Spec rewritten as two variants: (1) parent app without the `/childns` mapping correctly throws with the contextual message; (2) parent declaring the mapping (via `url.withMapping=true`) resolves and `entityNew` succeeds.

Matches ACF behaviour (ACF already throws this scenario per the LDEV-1697 tracker doc).

