### PR TITLE
LDEV-6342 throw on HBM write, drop dead tuplizer catch, log not stderr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [LDEV-6340](https://luceeserver.atlassian.net/browse/LDEV-6340) — Entities extending a `mappedSuperClass="true"` parent no longer log `failed to resolve parent entity` warnings on every SessionFactory build. Mapped superclasses aren't entities, so "parent not registered" is the expected state, not an error
 - [LDEV-1697](https://luceeserver.atlassian.net/browse/LDEV-1697) — Tightened entity resolution for `cfc="ns.Name"` references: a dotted ref now requires the matching `/ns` mapping to be declared in the current application. Previously a silent simple-name fallback resolved any registered `Name` entity regardless of namespace — iteration-order-dependent (passed on Windows, failed on Linux). The new throw on unresolvable refs names the source CFC and property: `Cannot resolve entity reference [ns.Name] on property [foo] of [...]`. Matches ACF behaviour
+- [LDEV-6342](https://luceeserver.atlassian.net/browse/LDEV-6342) — Fail fast on three silent-failure sites: HBM file write, dead tuplizer catch, Dialect `printStackTrace`
 
 ## 5.6.15.16
 

--- a/source/java/src/org/lucee/extension/orm/hibernate/Dialect.java
+++ b/source/java/src/org/lucee/extension/orm/hibernate/Dialect.java
@@ -9,6 +9,7 @@ import org.apache.felix.framework.BundleWiringImpl.BundleClassLoader;
 import org.lucee.extension.orm.hibernate.util.CommonUtil;
 import org.osgi.framework.Bundle;
 
+import lucee.commons.io.log.Log;
 import lucee.loader.engine.CFMLEngineFactory;
 import lucee.loader.util.Util;
 import lucee.runtime.db.DataSource;
@@ -33,7 +34,7 @@ public class Dialect {
 			// List all XML files in the OSGI-INF directory and below
 			ListUtil util = CFMLEngineFactory.getInstance().getListUtil();
 			Enumeration<URL> e = b.findEntries("org/hibernate/dialect", "*.class", true);
-			String path;
+			String path = null;
 			while (e.hasMoreElements()) {
 				try {
 					path = e.nextElement().getPath();
@@ -58,12 +59,18 @@ public class Dialect {
 					}
 				}
 				catch (Exception exx) {
-					exx.printStackTrace();
+					// expected — dialects can have missing transitive deps across Hibernate versions
+					Log log = CommonUtil.getORMLog();
+					if ( log != null ) log.log( Log.LEVEL_DEBUG, "hibernate",
+						"Skipping dialect class [" + path + "] that failed to load during OSGi scan", exx );
 				}
 			}
 		}
 		catch (Exception ex) {
-			ex.printStackTrace();
+			// total scan failure — registered set limited to the hardcoded list below
+			Log log = CommonUtil.getORMLog();
+			if ( log != null ) log.log( Log.LEVEL_WARN, "hibernate",
+				"Failed to scan OSGi bundle for Hibernate dialect classes; falling back to hardcoded list", ex );
 		}
 
 		dialects.setEL(CommonUtil.createKey("CUBRID"), "org.hibernate.dialect.CUBRIDDialect");
@@ -150,12 +157,13 @@ public class Dialect {
 
 	/**
 	 * Get the Hibernate dialect for the given Datasource
-	 * 
+	 *
 	 * @param ds
 	 *            - Datasource object to check dialect on
 	 *
 	 * @return the string dialect value, like "org.hibernate.dialect.PostgreSQLDialect"
 	 */
+	// currently unused
 	public static String getDialect(DataSource ds) {
 		String name = ds.getClassDefinition().getClassName();
 		if ("net.sourceforge.jtds.jdbc.Driver".equalsIgnoreCase(name)) {

--- a/source/java/src/org/lucee/extension/orm/hibernate/mapping/HBMCreator.java
+++ b/source/java/src/org/lucee/extension/orm/hibernate/mapping/HBMCreator.java
@@ -1928,15 +1928,17 @@ public class HBMCreator {
 	 * @param xml
 	 *            Fully-formed hibernate mapping XML
 	 */
-	public static void saveMapping(Component cfc, String xml) {
+	public static void saveMapping(Component cfc, String xml) throws PageException {
 		Resource res = getMappingResource(cfc);
 		if (res != null) {
 			try {
 				CommonUtil.write(res, xml, CommonUtil.UTF8(), false);
 			} catch (Exception e) {
-				Log log = CommonUtil.getORMLog();
-				if ( log != null ) log.log( Log.LEVEL_ERROR, "hibernate",
-					"failed to write HBM mapping file [" + res + "] for entity [" + HibernateCaster.getEntityName( cfc ) + "]", e );
+				PageException pe = ExceptionUtil.createException( (SessionFactoryData) null, cfc,
+					"Failed to write HBM mapping file [" + res + "] for entity [" + HibernateCaster.getEntityName( cfc ) + "]",
+					null );
+				pe.initCause( e );
+				throw pe;
 			}
 		}
 	}

--- a/source/java/src/org/lucee/extension/orm/hibernate/tuplizer/AbstractEntityTuplizerImpl.java
+++ b/source/java/src/org/lucee/extension/orm/hibernate/tuplizer/AbstractEntityTuplizerImpl.java
@@ -79,16 +79,9 @@ public class AbstractEntityTuplizerImpl extends AbstractEntityTuplizer {
 				// generator
 				if (meta != null && CommonUtil.isAnyType(type)) {
 					type = "string";
-					try {
-						String gen = CommonUtil.toString(meta.get("generator", null), null);
-						if (!Util.isEmpty(gen)) {
-							type = HBMCreator.getDefaultTypeForGenerator(gen, "string");
-						}
-					}
-					catch (Exception e) {
-						Log log = CommonUtil.getORMLog();
-						if ( log != null ) log.log( Log.LEVEL_WARN, "hibernate",
-							"failed to resolve generator type for property [" + name + "], defaulting to [string]", e );
+					String gen = CommonUtil.toString(meta.get("generator", null), null);
+					if (!Util.isEmpty(gen)) {
+						type = HBMCreator.getDefaultTypeForGenerator(gen, "string");
 					}
 				}
 				try {

--- a/tests/dialect/dialectRegistration.cfc
+++ b/tests/dialect/dialectRegistration.cfc
@@ -1,0 +1,20 @@
+component extends="org.lucee.cfml.test.LuceeTestCase" labels="orm" {
+
+	function run( testResults, testBox ) {
+
+		describe( "Dialect registry — characterisation test for LDEV-6342 scan-vs-hardcoded question", function() {
+
+			it( "registers a non-empty set of dialects after extension init", function() {
+				var result = _InternalRequest( template: "#uri()#/probe.cfm" );
+				expect( trim( result.filecontent ) ).toBe( "ok" );
+			});
+
+		});
+
+	}
+
+	private string function uri() {
+		return getDirectoryFromPath( contractPath( getCurrentTemplatePath() ) ) & "dialectRegistration";
+	}
+
+}

--- a/tests/dialect/dialectRegistration/Application.cfc
+++ b/tests/dialect/dialectRegistration/Application.cfc
@@ -1,0 +1,9 @@
+component {
+	this.name = "test-dialectRegistration-#hash( getCurrentTemplatePath() )#";
+	this.datasource = server.getDatasource( "h2", server._getTempDir( "orm-dialectRegistration" ) );
+	this.ormEnabled = true;
+	this.ormSettings = {
+		dbcreate: "dropcreate",
+		cfclocation: [ getDirectoryFromPath( getCurrentTemplatePath() ) ]
+	};
+}

--- a/tests/dialect/dialectRegistration/probe.cfm
+++ b/tests/dialect/dialectRegistration/probe.cfm
@@ -1,0 +1,93 @@
+<cfscript>
+// Characterisation test for the OSGi dialect scan in Dialect.java.
+// Goal: snapshot what gets registered so we can diff scan-on vs scan-off and decide
+// whether the static-init scan adds anything the hardcoded `dialects.setEL(...)` list
+// doesn't. See LDEV-6342.
+//
+// What this test answers:
+//   1. Are dialects actually registered?
+//   2. Does every registered key resolve via getDialect(name)?
+//   3. Do common short names (MySQL, Oracle, H2, ...) resolve?
+//   4. Do FQCN lookups (org.hibernate.dialect.MySQLDialect) resolve? — scan-only alias
+//   5. Do simple-class-name lookups (MySQLDialect) resolve? — scan-only alias
+//
+// Run with the scan enabled, capture output. Then comment out the static { ... } scan
+// block in Dialect.java, rerun. Diff the output. Any short-name dialects that disappear
+// were only registered by the scan and need to be added to the hardcoded list (or
+// declared unsupported). FQCN / simple-class lookups disappearing tells you whether
+// anyone actually relies on those alias forms.
+try {
+	dialectClass = createObject( "java", "org.lucee.extension.orm.hibernate.Dialect" );
+	dialects = dialectClass.getDialects();
+	keys = structKeyArray( dialects );
+	arraySort( keys, "textnocase" );
+
+	systemOutput( "", true );
+	systemOutput( "=== Dialect registry snapshot (total: #arrayLen( keys )#) ===", true );
+	for ( k in keys ) {
+		systemOutput( k & " -> " & dialects[ k ], true );
+	}
+	systemOutput( "=== end dialect registry snapshot ===", true );
+
+	// Sanity: every registered key must resolve via the public lookup.
+	unresolvable = [];
+	for ( k in keys ) {
+		resolved = dialectClass.getDialect( javaCast( "string", k ) );
+		if ( isNull( resolved ) || len( resolved ) == 0 )
+			arrayAppend( unresolvable, k );
+	}
+	if ( arrayLen( unresolvable ) )
+		throw( message="Dialects registered but unresolvable via getDialect(): [#arrayToList( unresolvable, ', ' )#]" );
+
+	// Common short names users actually pass via ormSettings.dialect. These should
+	// always resolve — they come from the hardcoded list, not the scan.
+	commonShort = [ "MySQL", "MySQL55", "MySQL57", "Oracle", "Oracle12c", "H2", "HSQL",
+		"PostgreSQL", "PostgreSQL95", "MariaDB", "MariaDB103", "DB2", "Sybase", "SQLServer" ];
+	missingShort = [];
+	for ( name in commonShort ) {
+		if ( isNull( dialectClass.getDialect( javaCast( "string", name ) ) ) )
+			arrayAppend( missingShort, name );
+	}
+
+	// FQCN — scan-only alias. Comment out the scan and these will fail.
+	fqcnSamples = [
+		"org.hibernate.dialect.MySQLDialect",
+		"org.hibernate.dialect.OracleDialect",
+		"org.hibernate.dialect.H2Dialect",
+		"org.hibernate.dialect.PostgreSQLDialect"
+	];
+	missingFQCN = [];
+	for ( name in fqcnSamples ) {
+		if ( isNull( dialectClass.getDialect( javaCast( "string", name ) ) ) )
+			arrayAppend( missingFQCN, name );
+	}
+
+	// Simple class name — scan-only alias. Comment out the scan and these will fail.
+	simpleClassSamples = [ "MySQLDialect", "OracleDialect", "H2Dialect", "PostgreSQLDialect" ];
+	missingSimpleClass = [];
+	for ( name in simpleClassSamples ) {
+		if ( isNull( dialectClass.getDialect( javaCast( "string", name ) ) ) )
+			arrayAppend( missingSimpleClass, name );
+	}
+
+	systemOutput( "", true );
+	systemOutput( "=== alias resolution ===", true );
+	systemOutput( "common short names (hardcoded list expected): missing=[#arrayToList( missingShort, ', ' )#]", true );
+	systemOutput( "FQCN samples (scan-only expected): missing=[#arrayToList( missingFQCN, ', ' )#]", true );
+	systemOutput( "simple class samples (scan-only expected): missing=[#arrayToList( missingSimpleClass, ', ' )#]", true );
+	systemOutput( "=== end alias resolution ===", true );
+
+	// Hard assertion: common short names MUST resolve regardless of scan state. The
+	// hardcoded list is the contract. If any of these fail, either the hardcoded
+	// list is missing entries or the createObject failed.
+	if ( arrayLen( missingShort ) )
+		throw( message="Common dialect short names did not resolve: [#arrayToList( missingShort, ', ' )#]" );
+
+	echo( "ok" );
+}
+catch ( any e ) {
+	systemOutput( "probe failed: " & e.message, true );
+	if ( !isNull( e.stacktrace ) ) systemOutput( e.stacktrace, true );
+	echo( e.message );
+}
+</cfscript>


### PR DESCRIPTION
https://luceeserver.atlassian.net/browse/LDEV-6342

- `HBMCreator.saveMapping` now throws on file-write failure instead of silently logging at ERROR; missing HBM files would otherwise produce confusing downstream failures
- Dropped a dead `catch` in `AbstractEntityTuplizerImpl` that masked nothing in practice
- `Dialect` registration logging routed through the orm logger instead of `printStackTrace` to stderr
- Adds `tests/dialect/dialectRegistration` probe locking down current dialect short-name resolution