### PR TITLE
LDEV-6343 resolve foreign-generator id type via relation cfc, throw on bad refs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [LDEV-6340](https://luceeserver.atlassian.net/browse/LDEV-6340) — Entities extending a `mappedSuperClass="true"` parent no longer log `failed to resolve parent entity` warnings on every SessionFactory build. Mapped superclasses aren't entities, so "parent not registered" is the expected state, not an error
 - [LDEV-1697](https://luceeserver.atlassian.net/browse/LDEV-1697) — Tightened entity resolution for `cfc="ns.Name"` references: a dotted ref now requires the matching `/ns` mapping to be declared in the current application. Previously a silent simple-name fallback resolved any registered `Name` entity regardless of namespace — iteration-order-dependent (passed on Windows, failed on Linux). The new throw on unresolvable refs names the source CFC and property: `Cannot resolve entity reference [ns.Name] on property [foo] of [...]`. Matches ACF behaviour
 - [LDEV-6342](https://luceeserver.atlassian.net/browse/LDEV-6342) — Fail fast on three silent-failure sites: HBM file write, dead tuplizer catch, Dialect `printStackTrace`
+- [LDEV-6343](https://luceeserver.atlassian.net/browse/LDEV-6343) — `generator="foreign"` resolves parent id type via the relation's `cfc=`, throws localized errors for missing/bad property references (fixes silent varchar id default and FK mismatch)
 
 ## 5.6.15.16
 

--- a/source/java/src/org/lucee/extension/orm/hibernate/mapping/HBMCreator.java
+++ b/source/java/src/org/lucee/extension/orm/hibernate/mapping/HBMCreator.java
@@ -730,8 +730,7 @@ public class HBMCreator {
 		if (!Util.isEmpty(str, true)) column.setAttribute("length", str);
 
 		// type
-		String type = getType(info, cfc, prop, meta, getDefaultTypeForGenerator(generator, foreignCFC, data), data);
-		// print.o(prop.getName()+":"+type+"::"+getDefaultTypeForGenerator(generator,foreignCFC));
+		String type = getType(info, cfc, prop, meta, getDefaultTypeForGenerator(generator, foreignCFC, cfc, prop, data), data);
 		if (!Util.isEmpty(type)) id.setAttribute("type", type);
 
 		// unsaved-value
@@ -740,40 +739,38 @@ public class HBMCreator {
 
 	}
 
-	private static String getDefaultTypeForGenerator(String generator, StringBuilder foreignCFC, SessionFactoryData data) {
+	private static String getDefaultTypeForGenerator(String generator, StringBuilder foreignCFC, Component sourceCFC, Property sourceProp, SessionFactoryData data) throws PageException {
 		String value = getDefaultTypeForGenerator(generator, null);
 		if (value != null) return value;
 
 		if ("foreign".equalsIgnoreCase(generator)) {
 			if (!Util.isEmpty(foreignCFC.toString())) {
-				try {
-					Component cfc = data.getEntityByCFCName(foreignCFC.toString(), false);
-					if (cfc != null) {
-						Property[] ids = getIds(cfc, cfc.getProperties(true, false, false, false), null, true, data);
-						if (ids != null && ids.length > 0) {
-							Property id = ids[0];
-							id.getDynamicAttributes();
-							Struct meta = id.getDynamicAttributes();
-							if (meta != null) {
-								String type = CommonUtil.toString(meta.get(TYPE, null));
-
-								if (!Util.isEmpty(type) && (!type.equalsIgnoreCase("any") && !type.equalsIgnoreCase("object"))) {
-									return type;
-								}
-
-								String g = CommonUtil.toString(meta.get(GENERATOR, null));
-								if (!Util.isEmpty(g)) {
-									return getDefaultTypeForGenerator(g, foreignCFC, data);
-								}
-
-							}
+				// Non-throwing lookup (LDEV-6340). null means the target CFC isn't a
+				// registered entity — a config error we surface immediately rather than
+				// swallowing and defaulting to "string", which produces a varchar id
+				// column that can't FK-constrain to the parent's integer id (LDEV-6343).
+				Component cfc = data.getEntityByCFCName(foreignCFC.toString(), false, null);
+				if (cfc == null) {
+					throw ExceptionUtil.createException( data, sourceCFC,
+						"Generator [foreign] on property [" + sourceProp.getName()
+						+ "] of entity [" + HibernateCaster.getEntityName( sourceCFC )
+						+ "] references CFC [" + foreignCFC + "] which is not a registered entity",
+						null );
+				}
+				Property[] ids = getIds(cfc, cfc.getProperties(true, false, false, false), null, true, data);
+				if (ids != null && ids.length > 0) {
+					Property id = ids[0];
+					Struct meta = id.getDynamicAttributes();
+					if (meta != null) {
+						String type = CommonUtil.toString(meta.get(TYPE, null));
+						if (!Util.isEmpty(type) && (!type.equalsIgnoreCase("any") && !type.equalsIgnoreCase("object"))) {
+							return type;
+						}
+						String g = CommonUtil.toString(meta.get(GENERATOR, null));
+						if (!Util.isEmpty(g)) {
+							return getDefaultTypeForGenerator(g, foreignCFC, sourceCFC, sourceProp, data);
 						}
 					}
-				}
-				catch (Exception e) {
-					Log log = CommonUtil.getORMLog();
-					if ( log != null ) log.log( Log.LEVEL_WARN, "hibernate",
-						"failed to resolve type for foreign generator referencing [" + foreignCFC + "], defaulting to [string]", e );
 				}
 			}
 			return "string";
@@ -865,7 +862,35 @@ public class HBMCreator {
 
 			if (sct.containsKey(PROPERTY)) {
 				String p = CommonUtil.toString(sct.get(PROPERTY), null);
-				if (!Util.isEmpty(p)) foreignCFC.append(p);
+				if (!Util.isEmpty(p)) {
+					// Resolve the named property's cfc= attribute → the target entity for
+					// the foreign-generator chain. Pre-fix this appended the property name
+					// itself, which never matched any registered entity (LDEV-6343).
+					Property targetProp = null;
+					Property[] all = cfc.getProperties(true, false, false, false);
+					if (all != null) {
+						for (int i = 0; i < all.length; i++) {
+							if (all[i].getName().equalsIgnoreCase(p)) { targetProp = all[i]; break; }
+						}
+					}
+					if (targetProp == null) {
+						throw ExceptionUtil.createException( data, cfc,
+							"Generator [foreign] on property [" + prop.getName()
+							+ "] of entity [" + HibernateCaster.getEntityName( cfc )
+							+ "] references property [" + p + "] which does not exist on this entity",
+							null );
+					}
+					Struct targetMeta = targetProp.getDynamicAttributes();
+					String targetCFC = targetMeta != null ? CommonUtil.toString(targetMeta.get(CFC, null), null) : null;
+					if (Util.isEmpty(targetCFC)) {
+						throw ExceptionUtil.createException( data, cfc,
+							"Generator [foreign] on property [" + prop.getName()
+							+ "] of entity [" + HibernateCaster.getEntityName( cfc )
+							+ "] references property [" + p + "] which has no [cfc] attribute (not a relation property)",
+							null );
+					}
+					foreignCFC.append(targetCFC);
+				}
 			}
 
 		}

--- a/tests/mapping/generatorForeignBadProperty.cfc
+++ b/tests/mapping/generatorForeignBadProperty.cfc
@@ -1,0 +1,30 @@
+component extends="org.lucee.cfml.test.LuceeTestCase" labels="orm" {
+
+	function run( testResults, testBox ) {
+
+		describe( "generator='foreign' with params={property='X'} where X doesn't exist on the entity (LDEV-6343)", function() {
+
+			it( "throws localized error naming the missing property", function() {
+				var actualMessage = "";
+				try {
+					_InternalRequest( template: "#uri()#/probe.cfm" );
+					fail( "expected ORM init to throw, but it succeeded" );
+				}
+				catch ( any e ) {
+					actualMessage = e.message;
+				}
+
+				expect( actualMessage ).toInclude( "foreign", "expected message to mention generator [foreign]; got: " & actualMessage );
+				expect( actualMessage ).toInclude( "BadProperty", "expected message to localize to entity [BadProperty]; got: " & actualMessage );
+				expect( actualMessage ).toInclude( "nonexistent", "expected message to name the missing property; got: " & actualMessage );
+			});
+
+		});
+
+	}
+
+	private string function uri() {
+		return getDirectoryFromPath( contractPath( getCurrentTemplatePath() ) ) & "generatorForeignBadProperty";
+	}
+
+}

--- a/tests/mapping/generatorForeignBadProperty/Application.cfc
+++ b/tests/mapping/generatorForeignBadProperty/Application.cfc
@@ -1,0 +1,9 @@
+component {
+	this.name = "test-generatorForeignBadProperty-#hash( getCurrentTemplatePath() )#";
+	this.datasource = server.getDatasource( "h2", server._getTempDir( "orm-generatorForeignBadProperty" ) );
+	this.ormEnabled = true;
+	this.ormSettings = {
+		dbcreate: "dropcreate",
+		cfclocation: [ getDirectoryFromPath( getCurrentTemplatePath() ) ]
+	};
+}

--- a/tests/mapping/generatorForeignBadProperty/BadProperty.cfc
+++ b/tests/mapping/generatorForeignBadProperty/BadProperty.cfc
@@ -1,0 +1,7 @@
+// generator="foreign" params={property='nonexistent'} but the entity has no
+// property called "nonexistent". After LDEV-6343 lands, ORM init should throw
+// a localized error naming this entity + the bad property reference.
+component persistent="true" table="bad_property" accessors="true" {
+	property name="id"   fieldtype="id" generator="foreign" params="{property='nonexistent'}";
+	property name="name" ormtype="string" length="100";
+}

--- a/tests/mapping/generatorForeignBadProperty/probe.cfm
+++ b/tests/mapping/generatorForeignBadProperty/probe.cfm
@@ -1,0 +1,6 @@
+<cfscript>
+// ORM init in Application.cfc throws before this template runs. The spec's
+// try/catch around _InternalRequest captures the throw and asserts message.
+entityNew( "BadProperty" );
+echo( "ok" );
+</cfscript>

--- a/tests/mapping/generatorForeignMissing.cfc
+++ b/tests/mapping/generatorForeignMissing.cfc
@@ -1,0 +1,42 @@
+component extends="org.lucee.cfml.test.LuceeTestCase" labels="orm" {
+
+	function run( testResults, testBox ) {
+
+		describe( "generator='foreign' referencing a missing CFC (LDEV-6343)", function() {
+
+			it( "throws at ORM init with foreign + entity + missing-CFC name in the message", function() {
+				// ORM init runs during Application.cfc evaluation inside _InternalRequest,
+				// so the probe template never executes — the throw propagates here.
+				var actualMessage = "";
+				try {
+					_InternalRequest( template: "#uri()#/probe.cfm" );
+					fail( "expected ORM init to throw, but it succeeded" );
+				}
+				catch ( any e ) {
+					actualMessage = e.message;
+				}
+
+				systemOutput( "", true );
+				systemOutput( "=== generatorForeignMissing captured ===", true );
+				systemOutput( "message: " & actualMessage, true );
+				systemOutput( "=== end ===", true );
+
+				// LDEV-6342 contract — these tokens should all appear in the message
+				// after the fix at HBMCreator:743. Currently: "foreign" is absent
+				// because the user-visible error comes from a different code path
+				// (SessionFactoryData.getEntityByCFCName) that doesn't localize to
+				// the source property/entity.
+				expect( actualMessage ).toInclude( "foreign", "expected message to mention generator [foreign]; got: " & actualMessage );
+				expect( actualMessage ).toInclude( "PersonDetail", "expected message to localize the bad reference to entity [PersonDetail]; got: " & actualMessage );
+				expect( actualMessage ).toInclude( "DoesNotExistAtAll", "expected message to name the missing CFC; got: " & actualMessage );
+			});
+
+		});
+
+	}
+
+	private string function uri() {
+		return getDirectoryFromPath( contractPath( getCurrentTemplatePath() ) ) & "generatorForeignMissing";
+	}
+
+}

--- a/tests/mapping/generatorForeignMissing/Application.cfc
+++ b/tests/mapping/generatorForeignMissing/Application.cfc
@@ -1,0 +1,9 @@
+component {
+	this.name = "test-generatorForeignMissing-#hash( getCurrentTemplatePath() )#";
+	this.datasource = server.getDatasource( "h2", server._getTempDir( "orm-generatorForeignMissing" ) );
+	this.ormEnabled = true;
+	this.ormSettings = {
+		dbcreate: "dropcreate",
+		cfclocation: [ getDirectoryFromPath( getCurrentTemplatePath() ) ]
+	};
+}

--- a/tests/mapping/generatorForeignMissing/PersonDetail.cfc
+++ b/tests/mapping/generatorForeignMissing/PersonDetail.cfc
@@ -1,0 +1,16 @@
+// generator="foreign" with property="parent" → looks up the parent property's
+// cfc= attribute → "DoesNotExistAtAll" → no such entity registered.
+//
+// Today (LDEV-6342 RED): HBMCreator.getDefaultTypeForGenerator catches the
+// PageException from getEntityByCFCName, logs WARN, defaults id type to
+// "string". Hibernate later fails at SF build with an unrelated error that
+// doesn't name the actual cause.
+//
+// After fix (LDEV-6342 GREEN): throw at the catch site with the property,
+// entity, and missing-CFC name in the message — points the user straight at
+// the typo.
+component persistent="true" table="person_detail" accessors="true" {
+	property name="id"     fieldtype="id" ormtype="integer" generator="foreign" property="parent";
+	property name="parent" fieldtype="one-to-one" cfc="DoesNotExistAtAll" constrained="true";
+	property name="bio"    ormtype="string" length="200";
+}

--- a/tests/mapping/generatorForeignMissing/probe.cfm
+++ b/tests/mapping/generatorForeignMissing/probe.cfm
@@ -1,0 +1,8 @@
+<cfscript>
+// ORM init in Application.cfc throws before this template ever runs when
+// PersonDetail references a missing CFC. The spec catches that throw and
+// asserts the message tokens. If ORM init unexpectedly succeeds, we get
+// here and the spec's fail() fires.
+entityNew( "PersonDetail" );
+echo( "ok" );
+</cfscript>

--- a/tests/mapping/generatorForeignNoOrmtype.cfc
+++ b/tests/mapping/generatorForeignNoOrmtype.cfc
@@ -1,0 +1,20 @@
+component extends="org.lucee.cfml.test.LuceeTestCase" labels="orm" {
+
+	function run( testResults, testBox ) {
+
+		describe( "generator='foreign' without explicit ormtype on the id (LDEV-6343)", function() {
+
+			it( "child id type resolves to parent's id type (integer), FK constraint creates, round-trip works", function() {
+				var result = _InternalRequest( template: "#uri()#/probe.cfm" );
+				expect( trim( result.filecontent ) ).toBe( "ok" );
+			});
+
+		});
+
+	}
+
+	private string function uri() {
+		return getDirectoryFromPath( contractPath( getCurrentTemplatePath() ) ) & "generatorForeignNoOrmtype";
+	}
+
+}

--- a/tests/mapping/generatorForeignNoOrmtype/Application.cfc
+++ b/tests/mapping/generatorForeignNoOrmtype/Application.cfc
@@ -1,0 +1,9 @@
+component {
+	this.name = "test-generatorForeignNoOrmtype-#hash( getCurrentTemplatePath() )#";
+	this.datasource = server.getDatasource( "h2", server._getTempDir( "orm-generatorForeignNoOrmtype" ) );
+	this.ormEnabled = true;
+	this.ormSettings = {
+		dbcreate: "dropcreate",
+		cfclocation: [ getDirectoryFromPath( getCurrentTemplatePath() ) ]
+	};
+}

--- a/tests/mapping/generatorForeignNoOrmtype/Person.cfc
+++ b/tests/mapping/generatorForeignNoOrmtype/Person.cfc
@@ -1,0 +1,6 @@
+component persistent="true" table="person_noormtype" accessors="true" {
+	property name="id"   fieldtype="id" ormtype="integer" generator="native";
+	property name="name" ormtype="string" length="100";
+
+	property name="detail" fieldtype="one-to-one" cfc="PersonDetail" mappedBy="parent" cascade="all";
+}

--- a/tests/mapping/generatorForeignNoOrmtype/PersonDetail.cfc
+++ b/tests/mapping/generatorForeignNoOrmtype/PersonDetail.cfc
@@ -1,0 +1,9 @@
+// DELIBERATELY no ormtype= on the id property. After LDEV-6343 lands the id
+// type should resolve to Person's integer id type. Today the bug defaults to
+// varchar(255), which then can't FK-constrain to Person's integer id and SF
+// init dies at schema generation.
+component persistent="true" table="person_detail_noormtype" accessors="true" {
+	property name="id"     fieldtype="id" generator="foreign" params="{property='parent'}";
+	property name="parent" fieldtype="one-to-one" cfc="Person" constrained="true";
+	property name="bio"    ormtype="string" length="200";
+}

--- a/tests/mapping/generatorForeignNoOrmtype/probe.cfm
+++ b/tests/mapping/generatorForeignNoOrmtype/probe.cfm
@@ -1,0 +1,36 @@
+<cfscript>
+// Save a Person + PersonDetail, round-trip, verify the shared integer id.
+// SF init must succeed (today it dies at FK constraint DDL). Loaded ids
+// must be numeric and equal.
+try {
+	transaction {
+		p = entityNew( "Person" );
+		p.setName( "Alice" );
+
+		d = entityNew( "PersonDetail" );
+		d.setBio( "loves Hibernate" );
+		d.setParent( p );
+		p.setDetail( d );
+
+		entitySave( p );
+	}
+	ormFlush();
+	ormClearSession();
+
+	loaded = entityLoad( "Person", p.getId(), true );
+	if ( isNull( loaded ) )
+		throw( message="entityLoad returned null" );
+	if ( isNull( loaded.getDetail() ) )
+		throw( message="expected linked PersonDetail, got null" );
+	if ( !isNumeric( loaded.getId() ) )
+		throw( message="expected numeric Person.id, got [#loaded.getId()#] (#getMetadata( loaded.getId() ).getName()#)" );
+	if ( !isNumeric( loaded.getDetail().getId() ) )
+		throw( message="expected numeric PersonDetail.id, got [#loaded.getDetail().getId()#]" );
+	if ( loaded.getId() != loaded.getDetail().getId() )
+		throw( message="shared-pk mismatch: person=[#loaded.getId()#] detail=[#loaded.getDetail().getId()#]" );
+	echo( "ok" );
+}
+catch ( any e ) {
+	echo( e.message );
+}
+</cfscript>

--- a/tests/mapping/generatorForeignNonRelation.cfc
+++ b/tests/mapping/generatorForeignNonRelation.cfc
@@ -1,0 +1,30 @@
+component extends="org.lucee.cfml.test.LuceeTestCase" labels="orm" {
+
+	function run( testResults, testBox ) {
+
+		describe( "generator='foreign' with property reference that exists but is not a relation (LDEV-6343)", function() {
+
+			it( "throws localized error noting the property has no cfc attribute", function() {
+				var actualMessage = "";
+				try {
+					_InternalRequest( template: "#uri()#/probe.cfm" );
+					fail( "expected ORM init to throw, but it succeeded" );
+				}
+				catch ( any e ) {
+					actualMessage = e.message;
+				}
+
+				expect( actualMessage ).toInclude( "foreign", "expected message to mention generator [foreign]; got: " & actualMessage );
+				expect( actualMessage ).toInclude( "NonRelation", "expected message to localize to entity [NonRelation]; got: " & actualMessage );
+				expect( actualMessage ).toInclude( "name", "expected message to name the non-relation property; got: " & actualMessage );
+			});
+
+		});
+
+	}
+
+	private string function uri() {
+		return getDirectoryFromPath( contractPath( getCurrentTemplatePath() ) ) & "generatorForeignNonRelation";
+	}
+
+}

--- a/tests/mapping/generatorForeignNonRelation/Application.cfc
+++ b/tests/mapping/generatorForeignNonRelation/Application.cfc
@@ -1,0 +1,9 @@
+component {
+	this.name = "test-generatorForeignNonRelation-#hash( getCurrentTemplatePath() )#";
+	this.datasource = server.getDatasource( "h2", server._getTempDir( "orm-generatorForeignNonRelation" ) );
+	this.ormEnabled = true;
+	this.ormSettings = {
+		dbcreate: "dropcreate",
+		cfclocation: [ getDirectoryFromPath( getCurrentTemplatePath() ) ]
+	};
+}

--- a/tests/mapping/generatorForeignNonRelation/NonRelation.cfc
+++ b/tests/mapping/generatorForeignNonRelation/NonRelation.cfc
@@ -1,0 +1,7 @@
+// generator="foreign" params={property='name'} — the `name` property exists
+// but it's a plain string column, not a one-to-one relation (no cfc= attribute).
+// After LDEV-6343 lands, ORM init should throw a localized error.
+component persistent="true" table="non_relation" accessors="true" {
+	property name="id"   fieldtype="id" generator="foreign" params="{property='name'}";
+	property name="name" ormtype="string" length="100";
+}

--- a/tests/mapping/generatorForeignNonRelation/probe.cfm
+++ b/tests/mapping/generatorForeignNonRelation/probe.cfm
@@ -1,0 +1,4 @@
+<cfscript>
+entityNew( "NonRelation" );
+echo( "ok" );
+</cfscript>


### PR DESCRIPTION
https://luceeserver.atlassian.net/browse/LDEV-6343

- `generator="foreign"` now resolves the id-property type via the relation's `cfc=` attribute (parent entity's id type) instead of silently defaulting to `string`, fixing FK type mismatch when the parent id is non-string
- Throws specific errors for misconfigured foreign-generator refs: target CFC not a registered entity, referenced property doesn't exist on this entity, referenced property has no `cfc=` (not a relation property). Each error names the source entity + property
- Adds 4 probe tests covering the bad-config scenarios: `generatorForeignBadProperty`, `generatorForeignMissing`, `generatorForeignNoOrmtype`, `generatorForeignNonRelation`