### PR TITLE
LDEV-6391 add cfclocation bad-path regression tests

### DIFF
--- a/tests/config/cfclocationBadPath.cfc
+++ b/tests/config/cfclocationBadPath.cfc
@@ -1,0 +1,30 @@
+component extends="org.lucee.cfml.test.LuceeTestCase" labels="orm" {
+
+	function run( testResults, testBox ) {
+
+		describe( "ORM cfclocation bad-path handling", function() {
+
+			it( "all-bad array silently falls back to defaultCFCLocation (request template dir)", function() {
+				var result = _InternalRequest( template: "#uri()#/allBadArray/test.cfm" );
+				expect( trim( result.filecontent ) ).toBe( "ok" );
+			});
+
+			it( "single bad string falls back to defaultCFCLocation", function() {
+				var result = _InternalRequest( template: "#uri()#/singleBadString/test.cfm" );
+				expect( trim( result.filecontent ) ).toBe( "ok" );
+			});
+
+			it( "mixed good and bad paths keeps only the good entries", function() {
+				var result = _InternalRequest( template: "#uri()#/mixed/test.cfm" );
+				expect( trim( result.filecontent ) ).toBe( "ok" );
+			});
+
+		});
+
+	}
+
+	private string function uri() {
+		return getDirectoryFromPath( contractPath( getCurrentTemplatePath() ) ) & "cfclocationBadPath";
+	}
+
+}

--- a/tests/config/cfclocationBadPath/allBadArray/Application.cfc
+++ b/tests/config/cfclocationBadPath/allBadArray/Application.cfc
@@ -1,0 +1,12 @@
+component {
+	this.name = "test-cfclocation-allbad-array-#hash( getCurrentTemplatePath() )#";
+	this.datasource = server.getDatasource( "h2", server._getTempDir( "orm-cfclocation-allbad-array" ) );
+	this.ormEnabled = true;
+	this.ormSettings = {
+		dbcreate: "dropcreate",
+		cfclocation: [
+			getDirectoryFromPath( getCurrentTemplatePath() ) & "doesNotExistA",
+			getDirectoryFromPath( getCurrentTemplatePath() ) & "doesNotExistB"
+		]
+	};
+}

--- a/tests/config/cfclocationBadPath/allBadArray/DefaultEntity.cfc
+++ b/tests/config/cfclocationBadPath/allBadArray/DefaultEntity.cfc
@@ -1,0 +1,10 @@
+component accessors="true" persistent="true" {
+
+	property
+		name     ="id"
+		type     ="string"
+		fieldtype="id"
+		ormtype  ="string";
+	property name="label" type="string";
+
+}

--- a/tests/config/cfclocationBadPath/allBadArray/test.cfm
+++ b/tests/config/cfclocationBadPath/allBadArray/test.cfm
@@ -1,0 +1,37 @@
+<cfscript>
+// All cfclocation entries point to nonexistent paths.
+// loadResources silently drops them -> empty list -> _load falls back to defaultCFCLocation
+// (the parent dir of this template). DefaultEntity.cfc lives here, so it must still load.
+
+ent = entityNew( "DefaultEntity", { id: createUUID(), label: "fallback-ok" } );
+entitySave( ent );
+ormFlush();
+
+result = queryExecute( "SELECT count(*) as cnt FROM DefaultEntity" );
+if ( result.cnt[ 1 ] != 1 )
+	throw( message="Expected 1 DefaultEntity row, got [#result.cnt[ 1 ]#]" );
+
+// Entity inside one of the (nonexistent) bad-path directories cannot exist.
+// Asking for an unknown entity must fail; capture the current error text so Plan J's
+// lazy resolution can be verified to preserve the user-visible failure message.
+errCaught = false;
+errType   = "";
+errMsg    = "";
+try {
+	entityNew( "DoesNotExist", { id: createUUID() } );
+}
+catch ( any e ) {
+	errCaught = true;
+	errType   = e.type;
+	errMsg    = e.message;
+}
+
+if ( !errCaught )
+	throw( message="Expected entityNew('DoesNotExist') to throw, but it did not" );
+
+// Pin the current behaviour: missing entity surfaces as an ORM/Hibernate error.
+// Plan J must preserve this user-visible failure mode.
+systemOutput( "[allBadArray] DoesNotExist error type=[#errType#] message=[#left( errMsg, 200 )#]", true );
+
+echo( "ok" );
+</cfscript>

--- a/tests/config/cfclocationBadPath/mixed/Application.cfc
+++ b/tests/config/cfclocationBadPath/mixed/Application.cfc
@@ -1,0 +1,12 @@
+component {
+	this.name = "test-cfclocation-mixed-#hash( getCurrentTemplatePath() )#";
+	this.datasource = server.getDatasource( "h2", server._getTempDir( "orm-cfclocation-mixed" ) );
+	this.ormEnabled = true;
+	this.ormSettings = {
+		dbcreate: "dropcreate",
+		cfclocation: [
+			getDirectoryFromPath( getCurrentTemplatePath() ) & "good",
+			getDirectoryFromPath( getCurrentTemplatePath() ) & "doesNotExist"
+		]
+	};
+}

--- a/tests/config/cfclocationBadPath/mixed/good/GoodEntity.cfc
+++ b/tests/config/cfclocationBadPath/mixed/good/GoodEntity.cfc
@@ -1,0 +1,10 @@
+component accessors="true" persistent="true" {
+
+	property
+		name     ="id"
+		type     ="string"
+		fieldtype="id"
+		ormtype  ="string";
+	property name="label" type="string";
+
+}

--- a/tests/config/cfclocationBadPath/mixed/test.cfm
+++ b/tests/config/cfclocationBadPath/mixed/test.cfm
@@ -1,0 +1,34 @@
+<cfscript>
+// cfclocation = [ goodPath, badPath ]. badPath silently dropped, goodPath kept.
+// GoodEntity from goodPath must load. Unknown entity must fail.
+
+ent = entityNew( "GoodEntity", { id: createUUID(), label: "mixed-good" } );
+entitySave( ent );
+ormFlush();
+
+result = queryExecute( "SELECT count(*) as cnt FROM GoodEntity" );
+if ( result.cnt[ 1 ] != 1 )
+	throw( message="Expected 1 GoodEntity row, got [#result.cnt[ 1 ]#]" );
+
+// Verify the user-set cfclocation still appears in metadata (Plan J should not change this either)
+metaLocations = getApplicationMetadata().ormSettings.cfclocation;
+if ( !isArray( metaLocations ) || arrayLen( metaLocations ) != 2 )
+	throw( message="Expected getApplicationMetadata().ormSettings.cfclocation to have 2 entries, got [#serializeJSON( metaLocations )#]" );
+
+errCaught = false;
+errMsg    = "";
+try {
+	entityNew( "DoesNotExist", { id: createUUID() } );
+}
+catch ( any e ) {
+	errCaught = true;
+	errMsg    = e.message;
+}
+
+if ( !errCaught )
+	throw( message="Expected entityNew('DoesNotExist') to throw, but it did not" );
+
+systemOutput( "[mixed] DoesNotExist message=[#left( errMsg, 200 )#]", true );
+
+echo( "ok" );
+</cfscript>

--- a/tests/config/cfclocationBadPath/singleBadString/Application.cfc
+++ b/tests/config/cfclocationBadPath/singleBadString/Application.cfc
@@ -1,0 +1,9 @@
+component {
+	this.name = "test-cfclocation-bad-string-#hash( getCurrentTemplatePath() )#";
+	this.datasource = server.getDatasource( "h2", server._getTempDir( "orm-cfclocation-bad-string" ) );
+	this.ormEnabled = true;
+	this.ormSettings = {
+		dbcreate: "dropcreate",
+		cfclocation: getDirectoryFromPath( getCurrentTemplatePath() ) & "doesNotExist"
+	};
+}

--- a/tests/config/cfclocationBadPath/singleBadString/DefaultEntity.cfc
+++ b/tests/config/cfclocationBadPath/singleBadString/DefaultEntity.cfc
@@ -1,0 +1,10 @@
+component accessors="true" persistent="true" {
+
+	property
+		name     ="id"
+		type     ="string"
+		fieldtype="id"
+		ormtype  ="string";
+	property name="label" type="string";
+
+}

--- a/tests/config/cfclocationBadPath/singleBadString/test.cfm
+++ b/tests/config/cfclocationBadPath/singleBadString/test.cfm
@@ -1,0 +1,30 @@
+<cfscript>
+// cfclocation set to a single string pointing at a nonexistent directory.
+// loadResources splits to a single-element array, that entry drops, empty list,
+// falls back to defaultCFCLocation. DefaultEntity.cfc lives here, must still load.
+
+ent = entityNew( "DefaultEntity", { id: createUUID(), label: "single-bad-string-ok" } );
+entitySave( ent );
+ormFlush();
+
+result = queryExecute( "SELECT count(*) as cnt FROM DefaultEntity" );
+if ( result.cnt[ 1 ] != 1 )
+	throw( message="Expected 1 DefaultEntity row, got [#result.cnt[ 1 ]#]" );
+
+errCaught = false;
+errMsg    = "";
+try {
+	entityNew( "DoesNotExist", { id: createUUID() } );
+}
+catch ( any e ) {
+	errCaught = true;
+	errMsg    = e.message;
+}
+
+if ( !errCaught )
+	throw( message="Expected entityNew('DoesNotExist') to throw, but it did not" );
+
+systemOutput( "[singleBadString] DoesNotExist message=[#left( errMsg, 200 )#]", true );
+
+echo( "ok" );
+</cfscript>


### PR DESCRIPTION
https://luceeserver.atlassian.net/browse/LDEV-6390

Adds regression tests pinning the ORM cfclocation failure-state behaviour ahead of LDEV-6391 (Lucee core lazy cfclocation resolution in `ORMConfigurationImpl`).

Three fixtures under `tests/config/cfclocationBadPath/`:

- **allBadArray** — `cfclocation = [bad1, bad2]` → falls back to defaultCFCLocation (request template dir), `DefaultEntity` loads
- **singleBadString** — `cfclocation = "bad"` → same fallback path
- **mixed** — `cfclocation = [good, bad]` → only good path kept; `getApplicationMetadata().ormSettings.cfclocation` still reflects the user-set entries

Each scenario also asserts the error text for unknown entities stays:

> `No entity (persistent component) with name [X] found, available entities are [Y]`
