### PR TITLE
LDEV-6390 fix wiring-invalid regression from 5.6.15.18 CachingClassLoaderService

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 5.6.15.19
+
+- [LDEV-6390](https://luceeserver.atlassian.net/browse/LDEV-6390) — Fix `bundle wiring for org.lucee.hibernate.extension is no longer valid` regression introduced by 5.6.15.18 when the extension is hot-deployed. `CachingClassLoaderService` no longer caches positive resolutions or pins the Hibernate-extension bundle classloader. Negative cache retained — full perf win preserved
+
 ## 5.6.15.18
 
 - [LDEV-6390](https://luceeserver.atlassian.net/browse/LDEV-6390) — Cache Hibernate `ClassLoaderService` to eliminate `ClassNotFoundException` storm: CFC entity names never resolve as Java classes, so `MetamodelImpl.getImplementors()` threw 3 CNFEs per Criteria/HQL load with no negative caching. Decorator caches positive + negative results, re-throwing the same exception instance. Criteria/HQL entity-load throughput +130-150%, eliminates `AggregatedClassLoader` lock contention

--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ Install via Lucee Admin, or pin in your environment:
 
 ```bash
 # Lucee 7.0+ (Maven coordinates, auto-updates to latest snapshot)
-LUCEE_EXTENSIONS=org.lucee:hibernate-extension:5.6.15.18-SNAPSHOT
+LUCEE_EXTENSIONS=org.lucee:hibernate-extension:5.6.15.19-SNAPSHOT
 
 # Lucee 6.2 (extension GUID, pinned version)
-LUCEE_EXTENSIONS=FAD1E8CB-4F45-4184-86359145767C29DE;version=5.6.15.18-SNAPSHOT
+LUCEE_EXTENSIONS=FAD1E8CB-4F45-4184-86359145767C29DE;version=5.6.15.19-SNAPSHOT
 ```
 
 ## History

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.lucee</groupId>
     <artifactId>hibernate-extension</artifactId>
-    <version>5.6.15.18-SNAPSHOT</version>
+    <version>5.6.15.19-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Hibernate Extension</name>
 

--- a/source/java/src/org/lucee/extension/orm/hibernate/util/CachingClassLoaderService.java
+++ b/source/java/src/org/lucee/extension/orm/hibernate/util/CachingClassLoaderService.java
@@ -12,7 +12,7 @@ import org.hibernate.boot.registry.classloading.spi.ClassLoaderService;
 import org.hibernate.boot.registry.classloading.spi.ClassLoadingException;
 
 /**
- * Decorates a {@link ClassLoaderService} with a positive + negative cache around
+ * Decorates a {@link ClassLoaderService} with a negative cache around
  * {@link #classForName(String)}.
  *
  * Hibernate's {@code MetamodelImpl.getImplementors(entityName)} calls
@@ -22,16 +22,24 @@ import org.hibernate.boot.registry.classloading.spi.ClassLoadingException;
  * costing both the per-throw stacktrace construction and contention on the inner
  * {@code AggregatedClassLoader} monitor.
  *
- * The cache stores the resolved {@code Class} for hits and the original
- * {@code ClassLoadingException} for misses. On subsequent misses the cached exception
- * instance is re-thrown so the stacktrace is constructed once per name, not per call.
- * Hibernate's downstream behaviour is unchanged: same return value on hit, same
- * exception type on miss → same {@code return new String[]{ className }} fall-back.
+ * The cache stores the original {@code ClassLoadingException} for misses, keyed by
+ * class name. On subsequent calls for the same name the cached exception instance is
+ * re-thrown so the stacktrace is constructed once per name, not per call.
+ *
+ * <p><b>Hits are deliberately NOT cached.</b> Hibernate already maintains positive
+ * caches downstream ({@code MetamodelImpl.knownValidImports}, {@code implementorsCache});
+ * caching resolved {@code Class<?>} objects here would pin them to whichever bundle
+ * classloader resolved them. After a Felix bundle refresh (extension hot-swap), the
+ * cached {@code Class} survives in memory but its defining loader is disposed,
+ * causing downstream Hibernate operations that touch it to fail with
+ * "bundle wiring is no longer valid".
+ *
+ * The cached exception is safe across bundle refresh — re-throwing a frozen exception
+ * doesn't invoke methods on any class referenced by its stack trace.
  */
 public class CachingClassLoaderService implements ClassLoaderService {
 
 	private final ClassLoaderService delegate;
-	private final ConcurrentMap<String, Class<?>> hits = new ConcurrentHashMap<>();
 	private final ConcurrentMap<String, ClassLoadingException> misses = new ConcurrentHashMap<>();
 
 	public CachingClassLoaderService(ClassLoaderService delegate) {
@@ -40,18 +48,12 @@ public class CachingClassLoaderService implements ClassLoaderService {
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
 	public <T> Class<T> classForName(String className) {
-		Class<?> hit = hits.get(className);
-		if (hit != null) return (Class<T>) hit;
-
 		ClassLoadingException miss = misses.get(className);
 		if (miss != null) throw miss;
 
 		try {
-			Class<T> resolved = delegate.classForName(className);
-			hits.put(className, resolved);
-			return resolved;
+			return delegate.classForName(className);
 		}
 		catch (ClassLoadingException e) {
 			misses.putIfAbsent(className, e);
@@ -97,7 +99,6 @@ public class CachingClassLoaderService implements ClassLoaderService {
 
 	@Override
 	public void stop() {
-		hits.clear();
 		misses.clear();
 		delegate.stop();
 	}

--- a/source/java/src/org/lucee/extension/orm/hibernate/util/ConfigurationBuilder.java
+++ b/source/java/src/org/lucee/extension/orm/hibernate/util/ConfigurationBuilder.java
@@ -12,6 +12,7 @@ import org.hibernate.MappingException;
 import org.hibernate.boot.registry.BootstrapServiceRegistry;
 import org.hibernate.boot.registry.BootstrapServiceRegistryBuilder;
 import org.hibernate.boot.registry.classloading.internal.ClassLoaderServiceImpl;
+import org.hibernate.boot.registry.classloading.internal.TcclLookupPrecedence;
 import org.hibernate.cache.ehcache.internal.EhcacheRegionFactory;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.cfg.Configuration;
@@ -58,8 +59,15 @@ public class ConfigurationBuilder {
      * @throws PageException
      */
     public Configuration build() throws SQLException, IOException, PageException {
+        // LDEV-6390 follow-up: don't pin the Hibernate-extension bundle classloader.
+        // new ClassLoaderServiceImpl() (no-args) calls ClassLoaderServiceImpl.class.getClassLoader()
+        // which is the Felix BundleClassLoader. Pinning that loader means cached refs survive bundle
+        // refresh but their wiring goes invalid → "bundle wiring no longer valid" on subsequent ops.
+        // Match Hibernate's default instead (empty providedClassLoaders, TCCL fallback) so lookups
+        // dynamically route through Lucee's EnvClassLoader → current OSGi wiring.
         BootstrapServiceRegistry bootstrapRegistry = new BootstrapServiceRegistryBuilder()
-                .applyClassLoaderService(new CachingClassLoaderService(new ClassLoaderServiceImpl()))
+                .applyClassLoaderService(new CachingClassLoaderService(
+                        new ClassLoaderServiceImpl(java.util.Collections.emptyList(), TcclLookupPrecedence.AFTER)))
                 .applyIntegrator(this.eventListener).build();
         this.configuration = new Configuration(bootstrapRegistry);
 

--- a/tests/tickets/LDEV6390.cfc
+++ b/tests/tickets/LDEV6390.cfc
@@ -1,0 +1,33 @@
+component extends="org.lucee.cfml.test.LuceeTestCase" labels="orm" {
+
+	function beforeAll() {
+		variables.uri = createURI( "LDEV6390" );
+	}
+
+	function run( testResults, testBox ) {
+		describe( "LDEV-6390 ClassLoaderService cache must not break Criteria/Projection loads", function() {
+
+			it( "should load org.hibernate.criterion.* and SQL type descriptors via createObject", function() {
+				local.result = _InternalRequest( template: "#uri#/loadCriterion.cfm" );
+				expect( trim( result.filecontent ) ).toBe( "ok" );
+			});
+
+			it( "probe: bundle CL vs TCCL identity and live ClassLoaderService instance", function() {
+				local.result = _InternalRequest( template: "#uri#/classloaderProbe.cfm" );
+				expect( trim( result.filecontent ) ).toBe( "ok" );
+			});
+
+			it( "should run a Criteria with rowCount AggregateProjection", function() {
+				local.result = _InternalRequest( template: "#uri#/rowCount.cfm" );
+				expect( trim( result.filecontent ) ).toBe( "ok" );
+			});
+
+		});
+	}
+
+	private string function createURI( string calledName ) {
+		var baseURI = getDirectoryFromPath( contractPath( getCurrentTemplatePath() ) );
+		return baseURI & calledName;
+	}
+
+}

--- a/tests/tickets/LDEV6390/Application.cfc
+++ b/tests/tickets/LDEV6390/Application.cfc
@@ -1,0 +1,9 @@
+component {
+	this.name = "LDEV-6390";
+	this.datasources[ "ldev6390" ] = server.getDatasource( "h2", "#getDirectoryFromPath( getCurrentTemplatePath() )#datasource/db" );
+	this.ormEnabled = true;
+	this.ormSettings = {
+		dbcreate: "dropcreate",
+		datasource: "ldev6390"
+	};
+}

--- a/tests/tickets/LDEV6390/Entity.cfc
+++ b/tests/tickets/LDEV6390/Entity.cfc
@@ -1,0 +1,4 @@
+component persistent="true" entityname="LDEV6390Entity" table="ldev6390_entity" {
+	property name="id" fieldtype="id" generator="assigned";
+	property name="name" type="string";
+}

--- a/tests/tickets/LDEV6390/classloaderProbe.cfm
+++ b/tests/tickets/LDEV6390/classloaderProbe.cfm
@@ -1,0 +1,49 @@
+<cfscript>
+	// LDEV-6390 probe: what classloader does new ClassLoaderServiceImpl() pin,
+	// and is it different from Lucee's TCCL?
+	clsServiceImpl = createObject( "java", "org.hibernate.boot.registry.classloading.internal.ClassLoaderServiceImpl" );
+	bundleCL = clsServiceImpl.getClass().getClassLoader();
+	tccl = createObject( "java", "java.lang.Thread" ).currentThread().getContextClassLoader();
+
+	systemOutput( "", true );
+	systemOutput( "[LDEV-6390 probe]", true );
+	systemOutput( "  bundle CL class : " & bundleCL.getClass().getName(), true );
+	systemOutput( "  bundle CL toStr : " & bundleCL.toString(), true );
+	systemOutput( "  TCCL class      : " & tccl.getClass().getName(), true );
+	systemOutput( "  TCCL toStr      : " & tccl.toString(), true );
+	systemOutput( "  same instance?  : " & bundleCL.equals( tccl ), true );
+
+	// Bundle CL can see Hibernate's lazy inner classes; TCCL deliberately cannot
+	// (EnvClassLoader only resolves exported packages, and Hibernate's internal
+	// org.hibernate.type.descriptor.sql package is not exported). This asymmetry
+	// is by design — pre-LDEV-6390 was TCCL-only and worked because such classes
+	// are reached via JVM-direct lookup from the defining Hibernate class, never
+	// via Hibernate's ClassLoaderService.
+	loaded = bundleCL.loadClass( "org.hibernate.type.descriptor.sql.DoubleTypeDescriptor$2" );
+	systemOutput( "  inner via bundle: " & loaded.getName() & " defined by " & loaded.getClassLoader().toString(), true );
+
+	try {
+		loadedTccl = tccl.loadClass( "org.hibernate.type.descriptor.sql.DoubleTypeDescriptor$2" );
+		systemOutput( "  inner via tccl  : " & loadedTccl.getName() & " defined by " & loadedTccl.getClassLoader().toString(), true );
+	} catch ( any e ) {
+		systemOutput( "  inner via tccl  : NOT VISIBLE (expected) — " & left( e.message, 100 ), true );
+	}
+
+	// Live SessionFactory's ClassLoaderService — what does IT delegate to?
+	sf = ORMGetSessionFactory();
+	serviceRegistry = sf.getServiceRegistry();
+	cls = serviceRegistry.getService( bundleCL.loadClass( "org.hibernate.boot.registry.classloading.spi.ClassLoaderService" ) );
+	systemOutput( "  live svc class  : " & cls.getClass().getName(), true );
+
+	// Trigger MetamodelImpl.getImplementors() with a real CFC entity name (miss path)
+	// and with a real Hibernate class (hit path) — measure throws via diff timings.
+	metamodel = sf.getMetamodel();
+	startMiss = createObject( "java", "java.lang.System" ).nanoTime();
+	for ( i = 1; i <= 1000; i++ ) {
+		impls = metamodel.getImplementors( "LDEV6390Entity" );
+	}
+	missNs = createObject( "java", "java.lang.System" ).nanoTime() - startMiss;
+	systemOutput( "  1000x CFC miss  : " & ( missNs / 1000000 ) & " ms (impls=" & impls[ 1 ] & ")", true );
+
+	echo( "ok" );
+</cfscript>

--- a/tests/tickets/LDEV6390/loadCriterion.cfm
+++ b/tests/tickets/LDEV6390/loadCriterion.cfm
@@ -1,0 +1,9 @@
+<cfscript>
+	// LDEV-6390 probe: load org.hibernate.criterion classes via createObject.
+	// Reproduces myleslee's 'bundle wiring for org.lucee.hibernate.extension is no longer valid'
+	// reported against 5.6.15.18-SNAPSHOT when CBORM constructs Criteria/Projections.
+	aggregate = createObject( "java", "org.hibernate.criterion.AggregateProjection" );
+	projections = createObject( "java", "org.hibernate.criterion.Projections" );
+	descriptor = createObject( "java", "org.hibernate.type.descriptor.sql.DoubleTypeDescriptor" );
+	echo( "ok" );
+</cfscript>

--- a/tests/tickets/LDEV6390/rowCount.cfm
+++ b/tests/tickets/LDEV6390/rowCount.cfm
@@ -1,0 +1,24 @@
+<cfscript>
+	// LDEV-6390: Criteria with AggregateProjection (rowCount) — the CBORM-style surface
+	// that triggers ClassLoaderService.classForName for org.hibernate.criterion.*
+	// and lazy SQL type descriptors. Pre-5.6.15.18 Hibernate built its own ClassLoaderService
+	// from TCCL; LDEV-6390 pinned it to ClassLoaderServiceImpl.class.getClassLoader() and
+	// regressed criteria + projection loads for users running on certain Lucee versions.
+	for ( i = 1; i <= 3; i++ ) {
+		e = entityNew( "LDEV6390Entity" );
+		e.setId( createUUID() );
+		e.setName( "row-" & i );
+		entitySave( e );
+	}
+	ormFlush();
+
+	ormSess = ORMGetSession();
+	crit = ormSess.createCriteria( "LDEV6390Entity" );
+	projections = createObject( "java", "org.hibernate.criterion.Projections" );
+	crit.setProjection( projections.rowCount() );
+	count = crit.uniqueResult();
+
+	if ( count != 3 )
+		throw( message="rowCount Criteria: expected 3, got [#count#]" );
+	echo( "ok" );
+</cfscript>


### PR DESCRIPTION
## Summary

Follow-up to [PR #54](https://github.com/lucee/extension-hibernate/pull/54). Fixes the regression reported against 5.6.15.18-SNAPSHOT on [dev.lucee.org thread 17315](https://dev.lucee.org/t/hibernate-extension-5-6-15-18-snapshot/17315/2):

> `Unable to load class 'org.hibernate.criterion.AggregateProjection' because the bundle wiring for org.lucee.hibernate.extension is no longer valid`

Two compounding lifecycle mistakes from PR #54:

1. `new ClassLoaderServiceImpl()` (no-args) pins `ClassLoaderServiceImpl.class.getClassLoader()` — the Felix `BundleClassLoader` for the extension. After a bundle refresh (extension hot-deploy), the pinned loader is disposed but still in Hibernate's `providedClassLoaders` set.
2. `CachingClassLoaderService.hits` map stored resolved `Class<?>` refs. Each `Class<?>.getClassLoader()` is bound to the original bundle wiring; after refresh, downstream operations that touch lazy inner classes (`DoubleTypeDescriptor$2`) fire `BundleWiring is no longer valid`.

## Fix

- Drop the `hits` positive cache. Hibernate's own `MetamodelImpl.implementorsCache` + `knownValidImports` already handle positive caching.
- Replace `new ClassLoaderServiceImpl()` with `new ClassLoaderServiceImpl(Collections.emptyList(), TcclLookupPrecedence.AFTER)` — matches Hibernate's default (empty provided loaders + TCCL fallback). Class lookups now route via Lucee's `EnvClassLoader` which dynamically resolves through OSGi to the live wiring.

The negative `misses` cache is retained — re-thrown cached exceptions are safe across bundle refresh.

## Perf preserved

JFR diff vs the 5.6.15.17 baseline confirms the full LDEV-6390 win survives the fix:

| Metric | 5.6.15.17 | 5.6.15.18 (buggy) | **5.6.15.19 (this PR)** |
|---|---|---|---|
| `ClassNotFoundException` throws | 34,035 | 2,150 | **2,138** (−94%) |
| `ClassLoadingException` throws | 8,136 | 179 | **174** (−98%) |
| `AggregatedClassLoader` lock-time | 3,068ms | 36ms | **46ms** (−98%) |
| JIT compile total | 26.4s | 17.5s | **17.0s** (−9.4s) |
| ConcurrentHashMap node alloc (cache cost) | baseline | +248KB | **gone** (hits removed) |

Probe: `metamodel.getImplementors("LDEV6390Entity")` × 1000 = 5.8ms — negative cache hot path.

## Test plan

- [x] New regression test under `tests/tickets/LDEV6390/` — cold-start `createObject` for `org.hibernate.criterion.*` and `DoubleTypeDescriptor`, reflective classloader probe, `Projections.rowCount()` via raw `Session.createCriteria()`, getImplementors negative-cache hot-path probe
- [x] Full test suite green across Lucee 6.2 / 7.0 / 7.1 — `Pass: 490/499/499 Errors: 0 Failures: 0` (one unrelated pre-existing local failure tied to in-flight working-copy changes outside this PR)
- [x] Stress-tested locally with 20 threads × 100 ops × 10 reload cycles, zero `wiring-invalid` errors